### PR TITLE
Session timeout 60min and no rolling

### DIFF
--- a/middleware/session/index.js
+++ b/middleware/session/index.js
@@ -2,17 +2,12 @@
 const session = require('express-session');
 const connectAzureTables = require('connect-azuretables')(session);
 
-const store = connectAzureTables.create({
-    table: process.env.AZURE_STORAGE_SESSIONS_TABLE_NAME,
-    sessionTimeOut: 30,
-    logger: console.log,
-    errorLogger: console.log,
-});
+const store = connectAzureTables.create({ table: process.env.AZURE_STORAGE_SESSIONS_TABLE_NAME, sessionTimeOut: 60 });
 
 module.exports = session({
     store: store,
     secret: process.env.SESSION_SIGNING_KEY,
     resave: false,
     saveUninitialized: false,
-    rolling: true,
+    rolling: false,
 });


### PR DESCRIPTION
Sets auth session to last for 60 min and turned of rolling as temp issue for problems with renewing auth token.