### PR TITLE
GraphService.prototype.getEvents takes parameter maxDurationHrs

### DIFF
--- a/middleware/graphql/resolvers/mutation/confirmPeriod.js
+++ b/middleware/graphql/resolvers/mutation/confirmPeriod.js
@@ -15,7 +15,7 @@ async function confirmPeriod(_obj, { startDateTime, endDateTime, entries }, cont
     if (!entries || entries.length === 0) return { success: false, error: 'No entries to confirm for the specified period.' };
     try {
         log('Confirming period %s to %s', startDateTime, endDateTime);
-        const calendarView = await context.services.graph.getEvents(startDateTime, endDateTime);
+        const calendarView = await context.services.graph.getEvents(startDateTime, endDateTime, 24);
         let batch = entries.reduce((b, entry) => {
             const event = calendarView.filter(e => e.id === entry.id)[0];
             if (!event) return;

--- a/middleware/graphql/resolvers/query/eventData.js
+++ b/middleware/graphql/resolvers/query/eventData.js
@@ -120,7 +120,7 @@ async function eventData(_obj, { startDateTime, endDateTime }, context) {
         matchedDuration = confirmedDuration;
     } else {
         log('Found no confirmed events from %s to %s, retrieving entries from Microsoft Graph', startDateTime, endDateTime);
-        events = await context.services.graph.getEvents(startDateTime, endDateTime);
+        events = await context.services.graph.getEvents(startDateTime, endDateTime, 24);
         events = events.map(evt => matchEvent(evt, projects, customers));
         matchedEvents = events.filter(evt => (evt.project && evt.project.id));
         matchedDuration = matchedEvents.reduce((sum, evt) => sum + evt.durationMinutes, 0);

--- a/services/graph.js
+++ b/services/graph.js
@@ -36,10 +36,11 @@ GraphService.prototype.getClient = function () {
 /**
  * Get events for the specified week
  * 
- * @param {*} startDateTime 
- * @param {*} endDateTime 
+ * @param {*} startDateTime  Start time (iso)
+ * @param {*} endDateTime End time (iso)
+ * @param {*} maxDurationHrs Max duration in hours
  */
-GraphService.prototype.getEvents = async function (startDateTime, endDateTime) {
+GraphService.prototype.getEvents = async function (startDateTime, endDateTime, maxDurationHrs) {
   try {
     log('Querying Graph /me/calendar/calendarView: %s', JSON.stringify({ startDateTime, endDateTime }));
     const { value } = await this.getClient()
@@ -67,12 +68,13 @@ GraphService.prototype.getEvents = async function (startDateTime, endDateTime) {
         durationMinutes: utils.getDurationMinutes(evt.start.dateTime, evt.end.dateTime),
       }));
     events = this.removeIgnoredEvents(events);
+    events = events.filter(evt => evt.durationHours <= maxDurationHrs);
     return events;
   } catch (error) {
     switch (error.statusCode) {
       case 401: {
         this.oauthToken = await refreshAccessToken(this.req);
-        return this.getEvents(startDateTime, endDateTime);
+        return this.getEvents(startDateTime, endDateTime, maxDurationHrs);
       }
       default: {
         throw new Error();


### PR DESCRIPTION
## This PR fixes ##
#103

`getEvents` takes parameter `maxDurationHrs` and filters out events that are too long before returning the result.

### Alternatives ###
The alternative would be to let graphql handle the filtering of events that are too long.