### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners - aka default reviewers for PRs
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+* @Puzzlepart/did365


### PR DESCRIPTION
## This PR fixes ##
Code Owners file,  sets @Puzzlepart/did365 as default reviewers on pull requests so you don't have to add them manually
