### PR TITLE
Using .isoWeek()instead of .week() to calculate week from startTime #225

### DIFF
--- a/utils/index.js
+++ b/utils/index.js
@@ -19,7 +19,7 @@ module.exports = {
      * Get week for the specified date
      */
     getWeek: (date) => {
-        return moment(date).week();
+        return moment(date).isoWeek();
     },
 
     /**


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions locally using `npm run watch`
- [ ] Make sure you've updated the CHANGELOG if applicable

### Description
Using `.isoWeek()` instead of `.week()` to calculate week from startTime.


### Relevant issues
Closes #225 