### PR TITLE
Removed i18next from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
         "highcharts": "8.0.2",
         "highcharts-react-official": "3.0.0",
         "http-errors": "1.7.3",
-        "i18next": "^19.3.4",
         "loglevel": "1.6.7",
         "loglevel-plugin-prefix": "0.8.4",
         "moment": "2.24.0",


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions locally using `npm run watch`
- [x] Make sure you've updated the CHANGELOG if applicable

### Description
Removed `i18next` from `package.json`.

This might solve the build issue(s) we're experiencing:

```
ERROR in ./lib/client/App.js
Module build failed (from ./node_modules/babel-loader/lib/index.js):
Error: [BABEL] D:\home\site\wwwroot\lib\client\App.js: Could not find plugin "proposal-numeric-separator". Ensure there is an entry in ./available-plugins.js for it. (While processing: "D:\\home\\site\\wwwroot\\node_modules\\@babel\\preset-env\\lib\\index.js")
```