### PR TITLE
Truncate event titles using CSS (#214)

### DIFF
--- a/client/components/Timesheet/EventList/index.tsx
+++ b/client/components/Timesheet/EventList/index.tsx
@@ -14,7 +14,7 @@ export const EventList = (props: IEventListProps) => {
             'title',
             'Title',
             { maxWidth: value(props, 'columnWidths.title', 400), minWidth: value(props, 'columnWidths.title', 320) },
-            (event: ITimeEntry) => <a href={event.webLink} target='_blank'>{event.title}</a>,
+            (event: ITimeEntry) => <a href={event.webLink} target='_blank' className='truncate' title={event.title}>{event.title}</a>,
         ),
         col(
             'time',

--- a/scss/layout.scss
+++ b/scss/layout.scss
@@ -39,3 +39,9 @@ h4 {
 h5 {
   font-size: 1.2em;
 }
+
+.truncate {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions locally using `npm run watch`
- [x] Make sure you've updated the CHANGELOG if applicable

### Description
Truncate event titles using CSS. Added class `truncate` to `scss\layout.scss` with the following rules:

```css
  white-space: nowrap;
  overflow: hidden;
  text-overflow: ellipsis;
```

Added the full event title to the `title` attribute:

![image](https://user-images.githubusercontent.com/7606007/79853194-093e5800-83c8-11ea-8258-4bc29fec39e9.png)


### Relevant issues
Closes #214