### PR TITLE
Date format support in Excel export

### DIFF
--- a/client/pages/Reports/TIME_ENTRIES.ts
+++ b/client/pages/Reports/TIME_ENTRIES.ts
@@ -5,7 +5,7 @@ import gql from 'graphql-tag';
  */
 export default gql`
     query {
-         timeentries(dateFormat: "LL")  {
+         timeentries(dateFormat: "MMM DD, YYYY kk:mm")  {
             title
             projectId
             durationHours

--- a/client/utils/exportExcel.ts
+++ b/client/utils/exportExcel.ts
@@ -38,7 +38,13 @@ export async function exportExcel(items: any[], options: IExcelExportOptions): P
         name: 'Sheet 1',
         data: [
             options.columns.map(c => c.name),
-            ...items.map(item => options.columns.map(col => item[col.fieldName])),
+            ...items.map(item => options.columns.map(col =>
+                (col.fieldName === "startTime" || col.fieldName === "endTime")
+                // v===raw value, t===type, where "d" is date
+                // consider changing localeString to be automatic (i.e. no params), although export might bomb in some cases
+                    ? { v: new Date(item[col.fieldName]).toLocaleString("en"), t: "d" } 
+                    : item[col.fieldName]
+            )),
         ],
     }];
     const workBook = xlsx.utils.book_new();


### PR DESCRIPTION
- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [X] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions locally using `npm run watch`
- [x] Make sure you've updated the CHANGELOG (if applicable)
- [X] Make sure strings/resources are added using our [resource files](https://github.com/Puzzlepart/did365/tree/dev/resources)

### Description
Excel export now formats `startTime` and `endTime` columns as dates (with time)
![image](https://user-images.githubusercontent.com/7300548/81064755-898dae80-8eda-11ea-9369-cf51458b1ccf.png)
This solves #137 

In addition, TIME_ENTRIES date format has been changed to include 24h-formatted time,
i.e `"MMM DD, YYYY kk:mm"`.
This solves #226 , while maintaining readability (using month shortname)

![image](https://user-images.githubusercontent.com/7300548/81064969-ef7a3600-8eda-11ea-9839-70142af9cf2c.png)



### Relevant issues
#137 
#226 