### PR TITLE
#137 formatting excel export dates

### DIFF
--- a/client/utils/exportExcel.ts
+++ b/client/utils/exportExcel.ts
@@ -43,7 +43,7 @@ export async function exportExcel(items: any[], options: IExcelExportOptions): P
             options.columns.map(c => c.name),
             ...items.map(item => options.columns.map(col => {
                 switch (value<ExcelColumnType>(col, 'data.excelColFormat', null)) {
-                    case 'date': return { v: moment(item[col.fieldName]).format("YYYY-MM-DD hh:mm"), t: "d" };
+                    case 'date': return { v: moment(item[col.fieldName]).format("YYYY-MM-DD HH:mm"), t: "d" };
                     default: return item[col.fieldName];
                 }
             })),


### PR DESCRIPTION
### Your checklist for this pull request
- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [X] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions locally using `npm run watch`
- [X] Make sure strings/resources are added using our [resource files](https://github.com/Puzzlepart/did365/tree/dev/resources)

### Description
Excel Export util now formats dates `YYYY-MM-DD HH:mm`, with moment for consistency.
(for future reference, `hh` is 12hr formatting, `HH` is 24hr formatting in `moment`

![image](https://user-images.githubusercontent.com/7300548/82022540-23005180-968d-11ea-96dd-08abc363c7b0.png)


### Relevant issues
Closes #137 