### PR TITLE
hotfix/compression-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "2.30.0",
         "@typescript-eslint/parser": "2.30.0",
-        "compression-webpack-plugin": "^3.1.0",
         "eslint": "6.8.0",
         "eslint-plugin-react": "7.19.0",
         "html-webpack-plugin": "^4.3.0",


### PR DESCRIPTION
`compression-webpack-plugin` has been moved to **dependencies** and don't need to be in **devDependencies**