### PR TITLE
HtmlWebpackPlugin using a template instead of inline hbs

### DIFF
--- a/views/index_template.hbs
+++ b/views/index_template.hbs
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<html>
+
 <head>
     <title>Did 365</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -9,3 +12,13 @@
     <meta name="msapplication-TileColor" content="#2b5797">
     <meta name="theme-color" content="#ffffff">
 </head>
+
+<body>
+    <main role='main'>
+        <div id="app"></div>
+    </main>
+    <script src="/js/vendors~did365.8b7e2c7e1c8ece634f47.js"></script>
+    <script src="/js/did365.8b7e2c7e1c8ece634f47.js"></script>
+</body>
+
+</html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,17 +69,8 @@ let config = {
         new webpack.NoEmitOnErrorsPlugin(),
         new CompressionPlugin(),
         new HtmlWebpackPlugin({
-            templateContent: `
-            <!DOCTYPE html>
-            <html>
-            {{head}}
-                <body>
-                    <main role='main'>
-                    <div id="app"></div>
-                    </main>
-                </body>
-            </html>`,
-            filename: "../../views/index.hbs",
+            template: path.resolve(__dirname, 'views/index_template.hbs'),
+            filename: path.resolve(__dirname, 'views/index.hbs'),
             inject: true,
         }),
     ],


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions locally using `npm run watch`
- [x] Make sure strings/resources are added using our [resource files](https://github.com/Puzzlepart/did365/tree/dev/resources)

### Description
HtmlWebpackPlugin using a template instead of inline hbs. With the current approach our `<head>` is skipped.