### PR TITLE
Better nav item rendering for non-admins

### DIFF
--- a/client/components/Navigation/Navigation.module.scss
+++ b/client/components/Navigation/Navigation.module.scss
@@ -20,13 +20,13 @@
         @media (min-width: 1200px) {
             max-width: 1140px;
         }
-        
+
         .nav {
             display: flex;
             flex-direction: row;
-            justify-content: space-evenly;
+            justify-content: start;
             width: 500px;
-            padding-left: 0;
+            padding-left: 8px;
             font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji,
                 Segoe UI Emoji;
 
@@ -34,6 +34,7 @@
                 display: flex;
                 align-items: center;
                 height: 100%;
+                margin: 0 8px;
 
                 .navLink {
                     display: flex;
@@ -42,7 +43,7 @@
                     font-size: 14px;
                     text-decoration: none;
 
-                    .navIcon{
+                    .navIcon {
                         display: none;
                     }
 
@@ -76,8 +77,8 @@
         width: 100%;
         z-index: 100;
         height: 50px;
-        padding-bottom:10px;
-        background-color:  #363533;
+        padding-bottom: 10px;
+        background-color: #363533;
 
 
         .container {


### PR DESCRIPTION
### Your checklist for this pull request
- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [X] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions locally using `npm run watch`
- [X] Make sure strings/resources are added using our [resource files](https://github.com/Puzzlepart/did365/tree/dev/resources)

### Description
Navigation items are spaced evenly across the 500px wide nav area today.
This looks good for admins, but not regular users, who have fewer nav items.
Switched to margin left/right spacing of items instead.

![image](https://user-images.githubusercontent.com/7300548/82791614-5ea9d100-9e6e-11ea-879c-110f29bebe1e.png)

Closes #388