### PR TITLE
Consistent syntax for resolvers/mutations in projects

### DIFF
--- a/middleware/graphql/resolvers/project.js
+++ b/middleware/graphql/resolvers/project.js
@@ -34,33 +34,33 @@ const typeDef = `
   }
 `
 
-async function createProject(_obj, { project }, { user, services: { storage: StorageService } }) {
+async function createProject(_obj, variables, ctx) {
   try {
-    await StorageService.createProject(project, user.id)
+    await ctx.services.storage.createProject(variables.project, ctx.user.id)
     return { success: true, error: null }
   } catch (error) {
     return { success: false, error: omit(error, 'requestId') }
   }
 }
 
-async function addLabelToProject(_obj, { projectId, labelId }, { services: { storage: StorageService } }) {
+async function addLabelToProject(_obj, variables, ctx) {
   try {
-    await StorageService.addLabelToProject(projectId, labelId)
+    await ctx.services.storage.addLabelToProject(variables.projectId, variables.labelId)
     return { success: true, error: null }
   } catch (error) {
     return { success: false, error: omit(error, 'requestId') }
   }
 }
 
-async function projects(_obj, variables, { services: { storage: StorageService } }) {
+async function projects(_obj, variables, ctx) {
   let [
     projects,
     customers,
     labels,
   ] = await Promise.all([
-    StorageService.getProjects(variables.customerKey, { sortBy: variables.sortBy }),
-    StorageService.getCustomers(),
-    StorageService.getLabels(),
+    ctx.services.storage.getProjects(variables.customerKey, { sortBy: variables.sortBy }),
+    ctx.services.storage.getCustomers(),
+    ctx.services.storage.getLabels(),
   ])
   projects = connectEntities(projects, customers, labels)
   return projects


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions locally using `npm run watch`
- [x] Make sure strings/resources are added using our [resource files](https://github.com/Puzzlepart/did365/tree/dev/resources)

### Description
Consistent syntax for resolvers/mutations in projects. Inconsistent syntax in graphql resolvers caused the issue fixed by #421. I think we should stick to `(_obj, variables, ctx)` in the function signature for the graphql resolvers, and stop doing e.g. `(_obj, { role }, { services: { storage: StorageService } })`.

### Relevant issues
Closes #420 
