### PR TITLE
Feature/sort hours desc

### DIFF
--- a/client/pages/Projects/ProjectDetails/TimeEntries.tsx
+++ b/client/pages/Projects/ProjectDetails/TimeEntries.tsx
@@ -11,7 +11,6 @@ import { isEmpty } from 'underscore'
 export const TimeEntries = () => {
     const { t } = useTranslation(['projects', 'common'])
     const context = useContext(ProjectDetailsContext)
-    context.timeentries.sort((a, b) => new Date(b.startDateTime).getTime() - new Date(a.startDateTime).getTime())
     return (
         <>
             {context.error && <UserMessage type={MessageBarType.error} text={t('timeEntriesErrorText')} />}

--- a/middleware/graphql/resolvers/timesheet.js
+++ b/middleware/graphql/resolvers/timesheet.js
@@ -80,7 +80,7 @@ async function timesheet(_obj, { startDateTime, endDateTime, dateFormat }, { use
             resourceId: user.id,
             startDateTime,
             endDateTime,
-        }),
+        }, true),
         StorageService.getLabels(),
     ])
 

--- a/services/storage.js
+++ b/services/storage.js
@@ -264,8 +264,7 @@ class StorageService {
      * @param filterValues Filtervalues
      * @param options Options
      */
-    async getTimeEntries({ projectId, resourceId, weekNumber, year, startDateTime, endDateTime }, options) {
-        options = options || {}
+    async getTimeEntries({ projectId, resourceId, weekNumber, year, startDateTime, endDateTime }, sortAsc, options = {}) {
         const q = this.tableUtil.query()
         const filter = [
             ['ProjectId', projectId, q.string, q.equal],
@@ -284,7 +283,9 @@ class StorageService {
                 RowKey: 'id'
             }
         )
-        result = result.sort((a, b) => new Date(a.startDateTime) - new Date(b.startDateTime))
+        result = sortAsc
+            ? result.sort((a, b) => new Date(a.startDateTime) - new Date(b.startDateTime))
+            : result.sort((a, b) => new Date(b.startDateTime) - new Date(a.startDateTime))
         return result
     }
 


### PR DESCRIPTION
### Description
This PR fixes the order of the time entries for projects.
![image](https://user-images.githubusercontent.com/28678468/91980867-3ad90f80-ed28-11ea-8d31-7df0cc28ae69.png)

New addition to this PR: Added paramtert to getTimeEntries to be able to sort differently for TimeSheets and Projects timeentries by adding a bool value to the function.

### Relevant issues
Closes #479
