### PR TITLE
Confirm hours/week button is now disabled instead of hidden when there's unmatched events

### DIFF
--- a/client/pages/Timesheet/ActionBar/ActionBar.module.scss
+++ b/client/pages/Timesheet/ActionBar/ActionBar.module.scss
@@ -12,6 +12,10 @@
     outline: none;
     color: rgb(50, 49, 48);
     font-weight: normal;
+
+    &[class*='is-disabled'] {
+      opacity: 0.4;
+    }
   }
 
   .unconfirmButton {

--- a/client/pages/Timesheet/ActionBar/commands.tsx
+++ b/client/pages/Timesheet/ActionBar/commands.tsx
@@ -79,9 +79,9 @@ export const CONFIRM_ACTIONS = (context: ITimesheetContext, t: TFunction): ICont
                     styles={buttonStyles} />
             )
         }
-        if(context.selectedPeriod.unmatchedDuration > 0) return null
         return (
             <PrimaryButton
+                disabled={context.selectedPeriod.unmatchedDuration > 0}
                 iconProps={{ iconName: 'CheckMark' }}
                 onClick={context.onSubmitPeriod}
                 text={t('timesheet.confirmHoursText')}


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [x] Check your code additions locally using `npm run watch`
- [x] Make sure strings/resources are added using our [resource files](https://github.com/Puzzlepart/did365/tree/dev/resources)

### Description
Confirm hours/week button is now disabled instead of hidden when there's unmatched events.