### PR TITLE
Fixed an issue where ClearManualMatchButton was visible when the period was forecasted

### DIFF
--- a/client/pages/Timesheet/Overview/ProjectColumn/index.tsx
+++ b/client/pages/Timesheet/Overview/ProjectColumn/index.tsx
@@ -87,12 +87,9 @@ const ProjectColumn = ({ event }: IProjectColumnProps): JSX.Element => {
                         <ProjectLink project={event.project} />
                     </div>
                     {!isEmpty(event.project.labels) && <Icon iconName='Tag' className={styles.labelIcon} />}
-                    {(event.manualMatch && !selectedPeriod.isConfirmed) && (
+                    {(event.manualMatch && !selectedPeriod.isLocked) && (
                         <ClearManualMatchButton
-                            onClick={() => dispatch({
-                                type: 'CLEAR_MANUAL_MATCH',
-                                payload: event.id,
-                            })}
+                            onClick={() => dispatch({ type: 'CLEAR_MANUAL_MATCH', payload: event.id })}
                             className={styles.clearButton} />
                     )}
                 </div>


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [x] Check your code additions locally using `npm run watch`
- [x] Make sure strings/resources are added using our [resource files](https://github.com/Puzzlepart/did365/tree/dev/resources)

### Description
Fixed an issue where ClearManualMatchButton was visible when the period was forecasted.
