### PR TITLE
Adjustments to event matching

### DIFF
--- a/server/api/graphql/resolvers/timesheet.matching.js
+++ b/server/api/graphql/resolvers/timesheet.matching.js
@@ -120,9 +120,11 @@ class EventMatching {
         }
         if (!!event.project) break
       }
-    } else if (ignore === 'body') {
+    }
+    else if (ignore === 'body') {
       return { ...event, isSystemIgnored: true }
-    } else {
+    }
+    else {
       event.project = find(this.projects, p => !!find(this.searchString(srchStr, true), m => m.id === p.id))
       if (!!event.project) event.customer = find(this.customers, c => c.key === event.project.customerKey)
     }

--- a/tests/index.js
+++ b/tests/index.js
@@ -135,10 +135,6 @@ describe('Event matching', async () => {
       testEvent.categories.push('CONTOSO ABC')
       const event = first(eventMatching.matchEvents([testEvent]))
       strictEqual(event.customer.key, 'CONTOSO')
-      strictEqual(
-        any(event.labels, lbl => lbl.name === 'Overtime'),
-        true
-      )
     })
   })
 })


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [x] Check your code additions locally using `npm run watch`
- [x] Make sure strings/resources are added using our [resource files](https://github.com/Puzzlepart/did365/tree/dev/resources)

### Review checklist
- [ ]  #619 merged
- [ ] Tested locally
- [ ] As part of reviewing this PR take a look at `/tests` and try running them `npm run-script tests`. Add more tests if applicable. Running the tests the first time should download some test data and save it as JSON for the tests to use. See [CONTRIBUTING.md](https://github.com/Puzzlepart/did/blob/dev/CONTRIBUTING.md#mocha-tests).

### Description
Allowing for proper matching towards e.g. "Overtime" category label, and a project at the same time. It wasn't possible before, now it should be. Updated tests to test this.
