### PR TITLE
Setting  simpleResolvers: true for GraphQL types

### DIFF
--- a/server/api/graphql/context.ts
+++ b/server/api/graphql/context.ts
@@ -44,14 +44,14 @@ export const createContext = async (request: any): Promise<Context> => {
   try {
     let isAuthorized = false
     let user = null
-    let subscription = get(request, 'user.subscription', { default: {} })
+    let subscription = get(request, 'user.subscription')
     if (!!request.token) {
       subscription = await new SubscriptionService().findSubscriptionWithToken(request.token)
       if (!subscription) throw new AuthenticationError(null)
       isAuthorized = true
     } else {
       isAuthorized = !!get(request, 'user')
-      user = {
+      user = isAuthorized && {
         ...pick(get(request, 'user', { default: {} }), 'id'),
         subscription: pick(subscription, 'id', 'name')
       }

--- a/server/api/graphql/resolvers/apiToken.types.ts
+++ b/server/api/graphql/resolvers/apiToken.types.ts
@@ -2,7 +2,7 @@
 import 'reflect-metadata'
 import { Field, ID, ObjectType } from 'type-graphql'
 
-@ObjectType({ description: 'A type that describes a ApiToken' })
+@ObjectType({ description: 'A type that describes a ApiToken', simpleResolvers: true })
 export class ApiToken {
   @Field(() => ID, { nullable: true, defaultValue: null })
   name: string

--- a/server/api/graphql/resolvers/customer.types.ts
+++ b/server/api/graphql/resolvers/customer.types.ts
@@ -2,7 +2,7 @@
 import 'reflect-metadata'
 import { ObjectType, InputType, Field, ID } from 'type-graphql'
 
-@ObjectType({ description: 'A type that describes a Customer' })
+@ObjectType({ description: 'A type that describes a Customer', simpleResolvers: true })
 export class Customer {
   @Field(() => ID)
   key: string

--- a/server/api/graphql/resolvers/label.types.ts
+++ b/server/api/graphql/resolvers/label.types.ts
@@ -2,7 +2,7 @@
 import 'reflect-metadata'
 import { ObjectType, InputType, Field, ID } from 'type-graphql'
 
-@ObjectType({ description: 'A type that describes a LabelObject' })
+@ObjectType({ description: 'A type that describes a LabelObject', simpleResolvers: true })
 export class LabelObject {
   @Field(() => ID)
   name: string

--- a/server/api/graphql/resolvers/notification.types.ts
+++ b/server/api/graphql/resolvers/notification.types.ts
@@ -2,7 +2,7 @@
 import 'reflect-metadata'
 import { Field, ObjectType, InputType, ID } from 'type-graphql'
 
-@ObjectType({ description: 'A type that describes a Notification' })
+@ObjectType({ description: 'A type that describes a Notification', simpleResolvers: true })
 export class Notification {
   @Field(() => ID)
   id: string

--- a/server/api/graphql/resolvers/outlookCategory.types.ts
+++ b/server/api/graphql/resolvers/outlookCategory.types.ts
@@ -2,7 +2,7 @@
 import 'reflect-metadata'
 import { Field, ID, ObjectType } from 'type-graphql'
 
-@ObjectType({ description: 'A type that describes a OutlookCategory' })
+@ObjectType({ description: 'A type that describes a OutlookCategory', simpleResolvers: true })
 export class OutlookCategory {
   @Field(() => ID)
   id: string

--- a/server/api/graphql/resolvers/project.types.ts
+++ b/server/api/graphql/resolvers/project.types.ts
@@ -3,7 +3,7 @@ import 'reflect-metadata'
 import { Field, ID, InputType, ObjectType } from 'type-graphql'
 import { Customer, OutlookCategory, LabelObject } from './types'
 
-@ObjectType({ description: 'A type that describes a Project' })
+@ObjectType({ description: 'A type that describes a Project', simpleResolvers: true  })
 export class Project {
   @Field(() => ID)
   id?: string

--- a/server/api/graphql/resolvers/role.types.ts
+++ b/server/api/graphql/resolvers/role.types.ts
@@ -2,7 +2,7 @@
 import 'reflect-metadata'
 import { Field, ID, InputType, ObjectType } from 'type-graphql'
 
-@ObjectType({ description: 'A type that describes a Role' })
+@ObjectType({ description: 'A type that describes a Role', simpleResolvers: true })
 export class Role {
   @Field(() => ID)
   name?: string

--- a/server/api/graphql/resolvers/timeentry.types.ts
+++ b/server/api/graphql/resolvers/timeentry.types.ts
@@ -3,7 +3,7 @@ import 'reflect-metadata'
 import { Field, Float, ID, InputType, ObjectType } from 'type-graphql'
 import { Project, Customer, User } from './types'
 
-@ObjectType({ description: 'A type that describes a TimeEntry' })
+@ObjectType({ description: 'A type that describes a TimeEntry', simpleResolvers: true })
 export class TimeEntry {
   @Field(() => ID)
   id: string

--- a/server/api/graphql/resolvers/timesheet.types.ts
+++ b/server/api/graphql/resolvers/timesheet.types.ts
@@ -3,7 +3,7 @@ import 'reflect-metadata'
 import { Field, Float, ID, InputType, ObjectType } from 'type-graphql'
 import { Customer, EventError, LabelObject, Project } from './types'
 
-@ObjectType({ description: 'A type that describes a Event' })
+@ObjectType({ description: 'A type that describes a Event', simpleResolvers: true })
 export class EventObject {
   @Field(() => ID)
   id: string
@@ -80,7 +80,7 @@ export class EventInput {
   manualMatch: boolean
 }
 
-@ObjectType({ description: 'A type that describes a TimesheetPeriod' })
+@ObjectType({ description: 'A type that describes a TimesheetPeriod', simpleResolvers: true  })
 export class TimesheetPeriodObject {
   @Field()
   id: string

--- a/server/api/graphql/resolvers/user.types.ts
+++ b/server/api/graphql/resolvers/user.types.ts
@@ -3,7 +3,7 @@ import 'reflect-metadata'
 import { Field, ID, InputType, ObjectType } from 'type-graphql'
 import { Role } from './types'
 
-@ObjectType({ description: 'A type that describes a Subscription' })
+@ObjectType({ description: 'A type that describes a Subscription', simpleResolvers: true })
 export class Subscription {
   @Field()
   id: string
@@ -17,7 +17,7 @@ export class Subscription {
   connectionString?: string
 }
 
-@ObjectType({ description: 'A type that describes a User' })
+@ObjectType({ description: 'A type that describes a User', simpleResolvers: true })
 export class User {
   @Field(() => ID)
   id?: string


### PR DESCRIPTION
### Your checklist for this pull request
- [ ] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [x] Check your code additions locally using `npm run watch`
- [x] Make sure strings/resources are added using our [resource files](https://github.com/Puzzlepart/did365/tree/dev/resources)

### Review checklist
- [x] Tested locally

### Description
https://typegraphql.com/docs/performance.html

This simple trick can speed up the execution up to 76%! The benchmarks show that using simple resolvers allows for as fast execution as with bare graphql-js - the measured overhead is only about ~13%, which is a much more reasonable value than 500%. Below you can see the benchmarks results:

  | 25 000 array items
-- | --
graphql-js | 265.52 ms
Standard TypeGraphQL | 310.36 ms
TypeGraphQL with a global middleware | 1253.28 ms
TypeGraphQL with "simpleResolvers" applied(and a global middleware) | 299.61 ms

This optimization is not turned on by default mostly because of the global middlewares and authorization feature.

By using "simple resolvers" we are turning them off, so we have to be aware of the consequences - @Authorized guard on fields won't work for that fields so they will be publicly available, as well as global middlewares won't be executed for that fields, so we might lost, for example, performance metrics or access logs.

That's why we should be really careful with using this tweak. The rule of thumb is to use "simple resolvers" only when it's really needed, like returning huge array of nested objects.