### PR TITLE
Remove forcast message when week is confirmed

### DIFF
--- a/client/pages/Timesheet/Overview/StatusBar/index.tsx
+++ b/client/pages/Timesheet/Overview/StatusBar/index.tsx
@@ -56,7 +56,7 @@ export const StatusBar = () => {
         iconName: 'CheckMark'
       })
     }
-    if (selectedPeriod.isForecasted) {
+    if (selectedPeriod.isForecasted && !selectedPeriod.isConfirmed) {
       messages.push({
         text: t('timesheet.periodForecastedText', {
           hours: DateUtils.getDurationString(selectedPeriod.forecastedHours, t)


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [x] Check your code additions locally using `npm run watch`
- [x] Make sure strings/resources are added using our [resource files](https://github.com/Puzzlepart/did365/tree/dev/.resources)
- [x] Make sure CHANGELOG.md is update if applicable

### Review checklist
- [x] Tested locally

### Description
Quick'n'easy. Removes forecast message when week is confirmed.

### How to test
1. Check out locally with [gh](https://github.com/cli/cli)
2. Forecast week
3. See forecast message
4. Confirm week
5. Forecast message should no longer be visible.

### Related issues
Closes #651
