### PR TITLE
Fixed an issue with the current week command in Timesheet

### DIFF
--- a/client/pages/Timesheet/ActionBar/navigateCommands.tsx
+++ b/client/pages/Timesheet/ActionBar/navigateCommands.tsx
@@ -1,12 +1,13 @@
 import { TFunction } from 'i18next'
 import { IContextualMenuItem } from 'office-ui-fabric'
 import { ITimesheetContext } from '../context'
+import { TimesheetScope } from '../types'
 import styles from './ActionBar.module.scss'
 
 const navigateCommands = [
   {
     title: (t: TFunction) => t('timesheet.goToCurrentWeek'),
-    add: null,
+    date: new Date(),
     iconName: 'RenewalCurrent',
     disabled: (context: ITimesheetContext) => context.scope.isCurrentWeek || context.loading
   },
@@ -32,7 +33,11 @@ export default (context: ITimesheetContext) =>
         iconOnly: true,
         disabled: cmd.disabled(context),
         iconProps: { iconName: cmd.iconName, className: styles.actionBarIcon },
-        onClick: () => context.dispatch({ type: 'SET_SCOPE', scope: context.scope.set(cmd?.add) }),
+        onClick: () =>
+          context.dispatch({
+            type: 'SET_SCOPE',
+            scope: cmd.add ? context.scope.set(cmd?.add) : new TimesheetScope(cmd.date)
+          }),
         title: cmd.title(context.t)
       } as IContextualMenuItem)
   )


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [x] Check your code additions locally using `npm run watch`
- [x] Make sure strings/resources are added using our [resource files](https://github.com/Puzzlepart/did365/tree/dev/.resources)
- [x] Make sure CHANGELOG.md is update if applicable

### Review checklist
- [x] Tested locally

### Description
Fixed an issue with the Timesheet where the current week command didn't do anything.

The issue was some changes is how the reducer was called.

The commands have a property for what to add to the current scope. So for instance "back" navigation has add `-1w` and "forward" has `1w`. Current week had `null` which worked with the previous approach, but not with this one.

Changed the `Current week` command to set date = `new Date()` instead and check in the `onClick` handler wether the command has `add` or `date` property:

```typescript
const navigateCommands = [
  {
    title: (t: TFunction) => t('timesheet.goToCurrentWeek'),
    date: new Date(),
    iconName: 'RenewalCurrent',
    disabled: (context: ITimesheetContext) => context.scope.isCurrentWeek || context.loading
  },
  {
    title: (t: TFunction) => t('timesheet.goToPrevWeek'),
    add: '-1w',
    iconName: 'Back',
    disabled: (context: ITimesheetContext) => context.loading
  },
  {
    title: (t: TFunction) => t('timesheet.goToNextWeek'),
    add: '1w',
    iconName: 'Forward',
    disabled: (context: ITimesheetContext) => context.loading
  }
]

export default (context: ITimesheetContext) =>
  navigateCommands.map(
    (cmd, key) =>
      ({
        key: `${key}`,
        iconOnly: true,
        disabled: cmd.disabled(context),
        iconProps: { iconName: cmd.iconName, className: styles.actionBarIcon },
        onClick: () =>
          context.dispatch({
            type: 'SET_SCOPE',
            scope: cmd.add ? context.scope.set(cmd?.add) : new TimesheetScope(cmd.date)
          }),
        title: cmd.title(context.t)
      } as IContextualMenuItem)
)
```

### Related issues
Closes #669
