### PR TITLE
Fix for submit actions for future periods

### DIFF
--- a/client/pages/Timesheet/ActionBar/submitCommands.tsx
+++ b/client/pages/Timesheet/ActionBar/submitCommands.tsx
@@ -5,6 +5,19 @@ import { Subscription } from 'types'
 import { ITimesheetContext } from '../context'
 import styles from './ActionBar.module.scss'
 
+/**
+ * Get shared submit item props
+ * 
+ * @param {string} key Key
+ * @param {string} iconName Icon name 
+ */
+const submitItemProps = (key: string, iconName: string): Partial<IContextualMenuItem> => ({
+  key,
+  styles: { root: { height: 44, marginLeft: 4 } },
+  iconProps: { iconName },
+  canCheck: true,
+})
+
 export default (context: ITimesheetContext, subscription: Subscription): IContextualMenuItem => ({
   key: 'SUBMIT_COMMANDS',
   onRender: () => {
@@ -12,40 +25,28 @@ export default (context: ITimesheetContext, subscription: Subscription): IContex
     const { isComplete, isForecast, isForecasted, isConfirmed, isPast } = context.selectedPeriod
     const cmd = {
       FORECAST_PERIOD: subscription.settings?.forecast?.enabled && {
-        key: 'FORECAST_PERIOD',
-        styles: { root: { height: 44, marginLeft: 4 } },
-        iconProps: { iconName: 'BufferTimeBefore' },
+        ...submitItemProps('FORECAST_PERIOD', 'BufferTimeBefore'),
         onClick: () => context.onSubmitPeriod(true),
-        canCheck: true,
         text: context.t('timesheet.forecastHoursText'),
         secondaryText: context.t('timesheet.forecastHoursSecondaryText')
       },
       UNFORECAST_PERIOD: subscription.settings?.forecast?.enabled && {
-        key: 'UNFORECAST_PERIOD',
-        styles: { root: { height: 44, marginLeft: 4 } },
-        iconProps: { iconName: 'Cancel' },
+        ...submitItemProps('UNFORECAST_PERIOD', 'Cancel'),
         onClick: () => context.onUnsubmitPeriod(true),
-        canCheck: true,
         text: context.t('timesheet.unforecastHoursText'),
         secondaryText: context.t('timesheet.unforecastHoursSecondaryText')
       },
       CONFIRM_PERIOD: {
-        key: 'CONFIRM_PERIOD',
+        ...submitItemProps('CONFIRM_PERIOD', 'CheckMark'),
         className: styles.confirmPeriodButton,
-        styles: { root: { height: 44, marginLeft: 4 } },
-        iconProps: { iconName: 'CheckMark' },
         onClick: () => context.onSubmitPeriod(false),
-        canCheck: true,
         text: context.t('timesheet.confirmHoursText'),
         secondaryText: context.t('timesheet.confirmHoursSecondaryText')
       },
       UNCONFIRM_PERIOD: {
-        key: 'UNCONFIRM_PERIOD',
+        ...submitItemProps('UNCONFIRM_PERIOD','Cancel'),
         className: styles.unconfirmPeriodButton,
-        styles: { root: { height: 44, marginLeft: 4 } },
-        iconProps: { iconName: 'Cancel' },
         onClick: () => context.onUnsubmitPeriod(false),
-        canCheck: true,
         text: context.t('timesheet.unconfirmHoursText'),
         secondaryText: context.t('timesheet.unconfirmHoursSecondaryText')
       }


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [x] Check your code additions locally using `npm run watch`
- [x] Make sure strings/resources are added using our [resource files](https://github.com/Puzzlepart/did/tree/dev/.resources)
- [x] Make sure [CHANGELOG.md](https://github.com/Puzzlepart/did/blob/dev/CHANGELOG.md) is updated if applicable
- [x] Make sure [Smoke tests](https://github.com/Puzzlepart/did/wiki/Smoke-tests) are updated if applicable
 
### Review checklist
- [x] Tested locally

### Review theme song
🎵  [Dark Sky - Angels](https://open.spotify.com/track/4TQmCn0e9L7XTiKY4Hk8X4?si=vxbaSIYoSi2tc_Pn5yjyLA) 🎵 

### Description
Fix for submit actions for future weeks/periods.

For a future week it was (before this PR) possible to confirm a period that was not complete.

### How to test
1. Check out locally with [gh](https://github.com/cli/cli)
2. Go to a future week
3. Confirm button should not be available if the week is not complete (all events not matched)