### PR TITLE
Added Last Year option to Reports

### DIFF
--- a/client/i18n/en-GB.json
+++ b/client/i18n/en-GB.json
@@ -293,7 +293,8 @@
     "officeLocationLabel": "Office Location",
     "departmentLabel": "Department",
     "mobilePhoneLabel": "Mobile phone",
-    "searchUserLabel": "Search in Azure Active Directory"
+    "searchUserLabel": "Search in Azure Active Directory",
+    "exportTypeLastYear": "Last year ({{year}})"
   },
   "navigation": {
     "timesheet": "Timesheet",

--- a/client/i18n/nb.json
+++ b/client/i18n/nb.json
@@ -292,7 +292,8 @@
     "officeLocationLabel": "Kontorsted",
     "departmentLabel": "Avdeling",
     "mobilePhoneLabel": "Mobiltelefon",
-    "searchUserLabel": "Søk i Azure Active Directory"
+    "searchUserLabel": "Søk i Azure Active Directory",
+    "exportTypeLastYear": "I fjor ({{year}})"
   },
   "navigation": {
     "timesheet": "Timeliste",

--- a/client/pages/Reports/queries.tsx
+++ b/client/pages/Reports/queries.tsx
@@ -44,6 +44,29 @@ const currentMonthQuery = (now: DateObject, t: TFunction) => {
 }
 
 /**
+ * Get last year query
+ *
+ * @param {DateObject} now Current date and time
+ * @param {TFunction} t Translate function
+ */
+const lastYearQuery = (now: DateObject, t: TFunction) => {
+  const { year } = now.toObject('year')
+  const obj = { year: year - 1 }
+  return {
+    key: 'lastYear',
+    text: t('common.exportTypeLastYear', obj),
+    iconName: 'Previous',
+    variables: {
+      query: {
+        ...obj,
+        endDateTime: now.$.toISOString()
+      }
+    },
+    exportFileName: `TimeEntries-${obj.year}-{0}.xlsx`
+  } as IReportsQuery
+}
+
+/**
  * Get current year query
  *
  * @param {DateObject} now Current date and time
@@ -94,7 +117,13 @@ const forecastQuery = (now: DateObject, t: TFunction) => {
  */
 export function getQueries<T = IReportsQuery>(t: TFunction): T[] {
   const now = new DateObject()
-  return [lastMonthQuery, currentMonthQuery, currentYearQuery, forecastQuery].map(
+  return [
+    lastMonthQuery,
+    currentMonthQuery,
+    lastYearQuery,
+    currentYearQuery,
+    forecastQuery
+  ].map(
     (q) => (q(now, t) as unknown) as T
   )
 }


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [x] Check your code additions locally using `npm run watch`
- [x] Make sure strings/resources are added using our [resource files](https://github.com/Puzzlepart/did/tree/dev/.resources)
- [x] Make sure [CHANGELOG.md](https://github.com/Puzzlepart/did/blob/dev/CHANGELOG.md) is updated if applicable
- [x] Make sure [Smoke tests](https://github.com/Puzzlepart/did/wiki/Smoke-tests) are updated if applicable
 
### Review checklist
- [x] Tested locally

### Description
Added last year query to Reports.

![image](https://user-images.githubusercontent.com/7606007/103521795-a0c1d900-4e79-11eb-9555-fe7dbae647be.png)

As it's referencing the same object, user export will automatically include the last year option aswell:

![image](https://user-images.githubusercontent.com/7606007/103521770-97d10780-4e79-11eb-8f94-dc35d2694b80.png)


### Related issues
Closes #774