### PR TITLE
Centered text in lists

### DIFF
--- a/client/components/List/List.module.scss
+++ b/client/components/List/List.module.scss
@@ -1,4 +1,8 @@
 .root {
   margin: 0 0 25px 0;
   position: relative;
+
+  [class*="ms-DetailsRow-fields"]{
+      align-items: center;
+  }
 }


### PR DESCRIPTION
### Your checklist for this pull request
- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [X] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [X] Check your code additions locally using `npm run watch`
- [X] Make sure strings/resources are added using our [resource files](https://github.com/Puzzlepart/did/tree/dev/.resources)
- [X] Make sure [CHANGELOG.md](https://github.com/Puzzlepart/did/blob/dev/CHANGELOG.md) is updated if applicable
- [X] Make sure [Smoke tests](https://github.com/Puzzlepart/did/wiki/Smoke-tests) are updated if applicable
 
### Review checklist
- [x] Tested locally

### Description
Texts in lists are off-center vertically.  
I centered it.

### Review Theme Song
🎵  [Aaron Marshall - Peace and Gravity](https://open.spotify.com/track/2xdMB3v24zqDaaK2QtIZAN) 🎵

**From this**
![image](https://user-images.githubusercontent.com/7300548/104361173-68be3400-5512-11eb-8357-b9a1ce1db27d.png)
**To this**  
![image](https://user-images.githubusercontent.com/7300548/104361281-85f30280-5512-11eb-8912-f6f026d76ec6.png)

**From this**
![image](https://user-images.githubusercontent.com/7300548/104361359-a1f6a400-5512-11eb-93bc-62e4cb62de1e.png)
**To this**
![image](https://user-images.githubusercontent.com/7300548/104361404-af139300-5512-11eb-896c-a3b94b7a0f72.png)

etc, you get the picture stuff is centered


### How to test
1. Check out locally with [gh](https://github.com/cli/cli)
2. Go to a page with off-center text, e.g. [/admin/users](http://localhost:9001/admin/users)
3. Compare with https://did.puzzlepart.com/admin/users
4. Observe that the text is now centered.

### Related issues
None, this is ultra-trivial