### PR TITLE
Calculated minutes should be a whole number

### DIFF
--- a/shared/utils/date.ts
+++ b/shared/utils/date.ts
@@ -70,7 +70,7 @@ export class DateUtils {
    */
   public getDurationString(hours: number, t: TFunction): string {
     const hoursPrecise = parseFloat(parseFloat(hours.toString()).toPrecision(5))
-    const minutes = ((hoursPrecise % 1) * 60)
+    const minutes = parseInt(((hoursPrecise % 1) * 60).toFixed())
     const hrsStr = t('common.hoursShortFormat', { hours: Math.floor(hoursPrecise) })
     const minsStr = t('common.minutesShortFormat', { minutes })
     if (minutes === 0) return hrsStr


### PR DESCRIPTION
### Your checklist for this pull request
- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [X] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [X] Check your code additions locally using `npm run watch`
- [X] Make sure strings/resources are added using our [resource files](https://github.com/Puzzlepart/did/tree/dev/.resources)
- [X] Make sure [CHANGELOG.md](https://github.com/Puzzlepart/did/blob/dev/CHANGELOG.md) is updated if applicable
- [X] Make sure [Smoke tests](https://github.com/Puzzlepart/did/wiki/Smoke-tests) are updated if applicable
 
### Review checklist
- [x] Tested locally

### Review theme song

🎵  [Mausland Band - Aggressive Alpine Skiing](https://open.spotify.com/track/45t9UuA15ZaTtUriGV6zgj?si=ty9HWIdoTj6ldxbm7jZiLQ) 🎵 

### Description

#### Before fix
![image](https://user-images.githubusercontent.com/7300548/106905851-e124a900-66fc-11eb-9de7-4cbaa8f9983f.png)

#### After fix
![image](https://user-images.githubusercontent.com/7300548/106905894-eb46a780-66fc-11eb-92b1-2a05b2d9fa02.png)


### How to test
1. Check out locally with [gh](https://github.com/cli/cli)
2. Run did watch locally
2. Create a 26-minute event in your calendar
3. Navigate to [production](https://did.puzzlepart.com)
4. Observe that rounding is wrong in your timesheet
5. Navigate to your running localhost:9001
6. Observe that rounding works

### Related issues
Closes #772 