### PR TITLE
Customers: Pivot selectedKey should be set to state.view, not params.view

### DIFF
--- a/client/pages/Customers/Customers.tsx
+++ b/client/pages/Customers/Customers.tsx
@@ -39,7 +39,7 @@ export const Customers: FunctionComponent = () => {
   return (
     <CustomersContext.Provider value={ctxValue}>
       <Pivot
-        selectedKey={params.view || 'search'}
+        selectedKey={state.view || 'search'}
         onLinkClick={({ props }) => dispatch(CHANGE_VIEW({ view: props.itemKey as CustomersView }))}
         styles={{ itemContainer: { paddingTop: 10 } }}>
         <PivotItem


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [x] Check your code additions locally using `npm run watch`
- [x] Make sure strings/resources are added using our [resource files](https://github.com/Puzzlepart/did/tree/dev/.resources)
- [x] Make sure [CHANGELOG.md](https://github.com/Puzzlepart/did/blob/dev/CHANGELOG.md) is updated if applicable
- [x] Make sure [Smoke tests](https://github.com/Puzzlepart/did/wiki/Smoke-tests) are updated if applicable
 
### Review checklist
- [x] Tested locally

### Description
Customers: Pivot `selectedKey` should be set to `state.view`, not `params.view`.

### Related issues
Hotfix that closes #856 
