### PR TITLE
expertimental: create category/calendar in google cal

### DIFF
--- a/server/graphql/resolvers/outlookCategory/index.ts
+++ b/server/graphql/resolvers/outlookCategory/index.ts
@@ -1,7 +1,8 @@
 /* eslint-disable tsdoc/syntax */
 import 'reflect-metadata'
 import { Arg, Authorized, Mutation, Query, Resolver } from 'type-graphql'
-import { Service } from 'typedi'
+import { Inject, Service } from 'typedi'
+import { Context } from '../../../graphql/context'
 import { MSGraphService } from '../../../services'
 import { IAuthOptions } from '../../authChecker'
 import { CreateOutlookCategoryResult, OutlookCategory } from './types'
@@ -23,8 +24,12 @@ export class OutlookCategoryResolver {
    * Constructor for OutlookCategoryResolver
    *
    * @param _msgraph - Microsoft Graph service
+   * @param _context - GraphQL context
    */
-  constructor(private readonly _msgraph: MSGraphService) {}
+  constructor(
+    private readonly _msgraph: MSGraphService,
+    @Inject('CONTEXT') private readonly _context: Context
+  ) {}
 
   /**
    * Get Outlook categories
@@ -32,6 +37,7 @@ export class OutlookCategoryResolver {
   @Authorized<IAuthOptions>({ userContext: true })
   @Query(() => [OutlookCategory], { description: 'Get Outlook categories' })
   async outlookCategories() {
+    if (this._context.provider === 'google') return []
     const categories = await this._msgraph.getOutlookCategories()
     return categories.map((c) => ({ ...c, key: c.id }))
   }

--- a/server/graphql/resolvers/project/index.ts
+++ b/server/graphql/resolvers/project/index.ts
@@ -1,9 +1,10 @@
 /* eslint-disable tsdoc/syntax */
 import 'reflect-metadata'
+import { Context } from '../../../graphql/context'
 import { Arg, Authorized, Mutation, Query, Resolver } from 'type-graphql'
-import { Service } from 'typedi'
+import { Inject, Service } from 'typedi'
 import { ProjectService } from '../../../services/mongo'
-import MSGraphService from '../../../services/msgraph'
+import { GoogleCalendarService, MSGraphService } from '../../../services'
 import { IAuthOptions } from '../../authChecker'
 import {
   CreateOrUpdateProjectResult,
@@ -30,11 +31,16 @@ export class ProjectResolver {
    *
    * @param _project - Project service
    * @param _msgraph - Microsoft Graph service
+   * @param _googleCalSvc - Google calendar service
+   * @param _context - GraphQL context
    */
   constructor(
     private readonly _project: ProjectService,
-    private readonly _msgraph: MSGraphService
-  ) {}
+    private readonly _msgraph: MSGraphService,
+    private readonly _googleCalSvc: GoogleCalendarService,
+    @Inject('CONTEXT') private readonly _context: Context
+    // eslint-disable-next-line unicorn/empty-brace-spaces
+  ) { }
 
   /**
    * Get projects
@@ -68,16 +74,33 @@ export class ProjectResolver {
     @Arg('options', () => ProjectOptions) options: ProjectOptions,
     @Arg('update', { nullable: true }) update: boolean
   ): Promise<CreateOrUpdateProjectResult> {
-    const p = new Project(project)
-    if (update) {
-      const success = await this._project.updateProject(p)
-      return { success }
-    } else {
-      const id = await this._project.addProject(p)
-      if (options.createOutlookCategory) {
-        await this._msgraph.createOutlookCategory(id)
+    try {
+      const p = new Project(project)
+      if (update) {
+        const success = await this._project.updateProject(p)
+        return { success }
+      } else {
+        const id = await this._project.addProject(p)
+        if (options.createOutlookCategory) {
+          switch (this._context.provider) {
+            case 'google': {
+              const ccal = await this._googleCalSvc.createCalendar({
+                summary: p.name,
+                description: `${p.description} [${id}]`
+              })
+              console.log(ccal)
+            }
+              break
+            default: {
+              await this._msgraph.createOutlookCategory(id)
+            }
+          }
+          return { success: true, id }
+        }
       }
-      return { success: true, id }
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log(error)
     }
   }
 }

--- a/server/services/google/index.ts
+++ b/server/services/google/index.ts
@@ -33,6 +33,15 @@ class GoogleCalendarService {
   }
 
   /**
+   * Create calendar
+   */
+  public async createCalendar(requestBody: calendar_v3.Schema$Calendar) {
+    return await this._cal.calendars.insert({
+      requestBody
+    })
+  }
+
+  /**
    * Get calendars
    *
    * @param accessRole - Access role


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [ ] Check your code additions locally using `npm run watch`
- [ ] Make sure strings/resources are added using our [resource files](https://github.com/Puzzlepart/did/tree/dev/.resources)
- [ ] Make sure [CHANGELOG.md](https://github.com/Puzzlepart/did/blob/dev/CHANGELOG.md) is updated if applicable
- [ ] Make sure [Smoke tests](https://github.com/Puzzlepart/did/wiki/Smoke-tests) are updated if applicable
 
### Description
Experimental feature as we're not looking to fully support Google anytime soon.

It's just interesting too see and learn what possibilities we have with did and Google.

It seems that calendars is the categories for Google Calendars. If we ask for the scope `https://www.googleapis.com/auth/calendar` we can add new calendars to the users Google account automatically like we're doing with Outlook categories.

We add the project name as `summary` and project description + project id as `description`. This is almost like a category with a key and a value. The name is displayed while the Did tag is in the description field.

![image](https://user-images.githubusercontent.com/7606007/111489644-9c981e80-873a-11eb-9da7-183faaa85da4.png)

![image](https://user-images.githubusercontent.com/7606007/111490048-fc8ec500-873a-11eb-8ad1-866ec32bafc3.png)

### Related discussions
https://github.com/Puzzlepart/did/discussions/893