### PR TITLE
fix for #939: Font sizes, forecast week button

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,5 +28,6 @@
   "i18n-ally.sourceLanguage": "en-GB",
   "i18n-ally.displayLanguage": "en-GB",
   "typescript.tsserver.experimental.enableProjectDiagnostics": false,
-  "editor.folding": true
+"editor.folding": true,
+"editor.tabSize": 2
 }

--- a/client/pages/Timesheet/ActionBar/useSubmitCommands.tsx
+++ b/client/pages/Timesheet/ActionBar/useSubmitCommands.tsx
@@ -121,7 +121,7 @@ export function useSubmitCommands(): IContextualMenuItem {
       if (commands.length > 1) {
         menuProps = {
           calloutProps: {
-            calloutWidth: 280
+            calloutWidth: 300
           },
           items: commands.map((command_) => ({
             ...(_.omit(command_, 'buttonStyles') as IContextualMenuItem),

--- a/client/pages/Timesheet/SummaryView/SummaryView.module.scss
+++ b/client/pages/Timesheet/SummaryView/SummaryView.module.scss
@@ -1,7 +1,6 @@
 .root {
   [class*="ms-DetailsRow-cell"] {
     background: transparent;
-    font-size: 1.2em;
     align-self: center;
     padding: 0px 12px;
 
@@ -18,7 +17,6 @@
       border: none;
       background: transparent;
       [class*="ms-DetailsRow-cell"] {
-        font-size: 1.2em;
         display: flex;
         align-items: center;
 

--- a/client/theme/dark.ts
+++ b/client/theme/dark.ts
@@ -93,5 +93,5 @@ export default {
     green: 'green',
     greenLight: '#dcdcdc'
   },
-  fonts
+  ...fonts
 } as PartialTheme

--- a/client/theme/fonts.ts
+++ b/client/theme/fonts.ts
@@ -2,9 +2,7 @@ import { PartialTheme } from '@fluentui/react/lib/Theme'
 
 export default {
   fonts: {
-    large: { fontSize: 32 },
-    medium: { fontSize: 16 },
+    medium: { fontSize: 14 },
     small: { fontSize: 14 },
-    xSmall: { fontSize: 10 }
   }
 } as PartialTheme

--- a/client/theme/light.ts
+++ b/client/theme/light.ts
@@ -46,5 +46,5 @@ export default {
     white: '#ffffff',
     whiteTranslucent40: '#ffffff88'
   },
-  fonts
+  ...fonts
 } as PartialTheme


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [x] Check your code additions locally using `npm run watch`
- [x] Make sure strings/resources are added using our [resource files](https://github.com/Puzzlepart/did/tree/dev/.resources)
- [x] Make sure [CHANGELOG.md](https://github.com/Puzzlepart/did/blob/dev/CHANGELOG.md) is updated if applicable
- [x] Make sure [Smoke tests](https://github.com/Puzzlepart/did/wiki/Smoke-tests) are updated if applicable
 
### Review checklist
- [x] Tested locally

### Review theme song
🎵  [Jubël - Someone](https://open.spotify.com/track/68zNuCEl9UHTbcBltW2uDv?si=06373e6fdff048e8) 🎵 

### Description
* Made forecast week-button 20px wider
![image](https://user-images.githubusercontent.com/7300548/116066461-624e6500-a688-11eb-856a-986dc27f8bfb.png)
![image](https://user-images.githubusercontent.com/7300548/116066467-637f9200-a688-11eb-94d9-4a3fe5e1cba7.png)


* Fixed default font sizes (fonts.ts partial wasn't being included before, spread operator the rescue)
![image](https://user-images.githubusercontent.com/7300548/116066541-78f4bc00-a688-11eb-966a-14f3eaaafc6c.png)

* Removed unnecessary timesheet summary view font size declaration, since it's covered by theme font settings



### How to test
1. Check out locally with [gh](https://github.com/cli/cli)
2. Navigate to timesheet
3. Observe that the time sheet event font is now 14px instead of 12px (this is global for most 12px fonts)
3. Click "forecast week"
4. Observe that all the text in the button is visible

### Related issues
Closes #939 