### PR TITLE
Cache expiry set to 20s for MSGraphService.getEvents

### DIFF
--- a/server/services/cache.ts
+++ b/server/services/cache.ts
@@ -15,9 +15,23 @@ export enum CacheScope {
 
 export type CacheKey = string | string[]
 
-type CacheOptions = {
+/**
+ * Cache options
+ */
+export type CacheOptions = {
+  /**
+   * Cache key
+   */
   key: CacheKey
+
+  /**
+   * Cache expiry in seconds
+   */
   expiry?: number
+
+  /**
+   * Cache scope
+   */
   scope?: CacheScope
 }
 

--- a/server/services/msgraph/index.ts
+++ b/server/services/msgraph/index.ts
@@ -9,7 +9,7 @@ import _ from 'underscore'
 import { EventObject } from '../../graphql'
 import { Context } from '../../graphql/context'
 import { environment } from '../../utils'
-import { CacheScope, CacheService } from '../cache'
+import { CacheOptions, CacheScope, CacheService } from '../cache'
 import MSOAuthService, { MSAccessTokenOptions } from '../msoauth'
 import { MSGraphOutlookCategory } from './types'
 
@@ -242,9 +242,10 @@ class MSGraphService {
     endDateTimeIso: string
   ): Promise<EventObject[]> {
     try {
-      const cacheOptions = {
+      const cacheOptions: CacheOptions= {
         key: ['events', startDateTimeIso, endDateTimeIso],
-        scope: CacheScope.USER
+        scope: CacheScope.USER,
+        expiry: 20
       }
       const events = await this._cache.usingCache(async () => {
         const query = {


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [x] Check your code additions locally using `npm run watch`
- [x] Make sure strings/resources are added using our [resource files](https://github.com/Puzzlepart/did/tree/dev/.resources)
- [x] Make sure [CHANGELOG.md](https://github.com/Puzzlepart/did/blob/dev/CHANGELOG.md) is updated if applicable
- [x] Make sure [Smoke tests](https://github.com/Puzzlepart/did/wiki/Smoke-tests) are updated if applicable
 
### Review checklist
- [x] Tested locally

### Description
Cache expiry set to 20s for MSGraphService.getEvents