### PR TITLE
adjusted last month report query to include January

### DIFF
--- a/server/services/report.ts
+++ b/server/services/report.ts
@@ -79,7 +79,7 @@ export class ReportService {
         CURRENT_YEAR: {
           year: d.toObject().year
         }
-      })[preset] || {}
+      }[preset] || {})
   }
 
   /**


### PR DESCRIPTION
### Your checklist for this pull request
- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [X] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [X] Check your code additions locally using `npm run watch`
- [X] Make sure strings/resources are added using our [resource files](https://github.com/Puzzlepart/did/tree/dev/.resources)
- [X] Make sure [CHANGELOG.md](https://github.com/Puzzlepart/did/blob/dev/CHANGELOG.md) is updated if applicable
- [X] Make sure [Smoke tests](https://github.com/Puzzlepart/did/wiki/Smoke-tests) are updated if applicable
 
### Review checklist
- [X] Tested locally

### Description
Fixes a bug where time entries for last month would not be loaded in January

### How to test
1. Check out locally with [gh](https://github.com/cli/cli)
2. Go reports
3. Choose the last month query
4. Observe that there are time entries

### Related issues
Closes #1024 