### PR TITLE
Better notification indication for mobile

### DIFF
--- a/client/parts/UserMenu/MenuItem/index.tsx
+++ b/client/parts/UserMenu/MenuItem/index.tsx
@@ -24,7 +24,10 @@ export const MenuItem: React.FC<IMenuItemProps> = (props) => {
     <div
       className={className.join(' ')}
       title={props.title}
-      style={props.style}
+      style={{
+        ...props.style,
+        position: 'relative'
+      }}
       onClick={onClick}
     >
       {props.iconProps && (

--- a/client/parts/UserNotifications/NotificationIndicator/index.tsx
+++ b/client/parts/UserNotifications/NotificationIndicator/index.tsx
@@ -4,15 +4,20 @@ import _ from 'underscore'
 import { UserNotificationsContext } from '../context'
 import styles from './NotificationIndicator.module.scss'
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface INotificationIndicatorProps extends React.HTMLProps<HTMLDivElement> {
+
+}
+
 /**
  * @category Function Component
  */
-export const NotificationIndicator: React.FC = () => {
+export const NotificationIndicator: React.FC<INotificationIndicatorProps> = (props) => {
   const { notifications, count } = useContext(UserNotificationsContext)
   return (
     <div
       className={styles.root}
-      style={{ opacity: _.isEmpty(notifications) ? 0 : 1 }}
+      style={{ ...props.style, opacity: _.isEmpty(notifications) ? 0 : 1 }}
     >
       {count}
     </div>

--- a/client/parts/UserNotifications/index.tsx
+++ b/client/parts/UserNotifications/index.tsx
@@ -31,8 +31,15 @@ export const UserNotifications: React.FC<IUserNotificationsProps> = ({
         <MenuItem
           onClick={togglePanel}
           iconProps={{ iconName }}
-          text={t('notifications.headerText')}
-        />
+          text={t('notifications.headerText')}>
+          <NotificationIndicator style={{
+            top: 8,
+            left: 22,
+            height: 12,
+            width: 14,
+            fontSize: 8
+          }} />
+        </MenuItem>
       ) : (
         <div className={styles.root} onClick={togglePanel}>
           <div className={styles.icon}>


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev branch*.
- [x] Check your code additions locally using `npm run watch`
- [x] Make sure strings/resources are added using our [resource files](https://github.com/Puzzlepart/did/tree/dev/.resources)
- [x] Make sure [CHANGELOG.md](https://github.com/Puzzlepart/did/blob/dev/CHANGELOG.md) is updated if applicable
- [x] Make sure [Smoke tests](https://github.com/Puzzlepart/did/wiki/Smoke-tests) are updated if applicable
 
### Review checklist
- [x] Tested locally

### Description
Currently we're only displaying notification count on your profile picture for mobile.

<img width="357" alt="image" src="https://user-images.githubusercontent.com/7606007/184087009-4b47515d-974a-42b5-a248-71d6b7242cc8.png">

We should also display it on the notifications menu item.

<img width="295" alt="image" src="https://user-images.githubusercontent.com/7606007/184086685-ac07ab1d-aa89-4430-90ba-ea582eaed77e.png">