### PR TITLE
actual fix for ISO week/year inconsistency in summary reports

### DIFF
--- a/shared/utils/DateObject.test.ts
+++ b/shared/utils/DateObject.test.ts
@@ -68,3 +68,58 @@ test('DateObject.fromObject with string inputs', (t) => {
   t.is(isoWeek, 1)
   t.is(isoYear, 2023)
 })
+
+// toObject() ISO week/year consistency tests
+test('toObject returns ISO year matching ISO week at year boundaries', (t) => {
+  // Week 1 of 2026 starts on December 29, 2025 (calendar year 2025, ISO year 2026)
+  const date = new DateObject().fromObject({ year: 2026, week: 1 })
+  const obj = date.toObject()
+
+  t.is(obj.week, 1, 'Should be ISO week 1')
+  t.is(obj.year, 2026, 'Should be ISO year 2026, not calendar year 2025')
+})
+
+test('toObject returns ISO year 2020 for Jan 1 2021 (week 53 of 2020)', (t) => {
+  // January 1, 2021 is a Friday in ISO week 53 of 2020
+  const date = new DateObject(new Date(2021, 0, 1))
+  const obj = date.toObject()
+
+  t.is(obj.week, 53, 'Should be ISO week 53')
+  t.is(obj.year, 2020, 'Should be ISO year 2020, not calendar year 2021')
+})
+
+test('toObject returns ISO year 2021 for Jan 4 2021 (week 1 of 2021)', (t) => {
+  // January 4, 2021 is the Monday of ISO week 1, 2021
+  const date = new DateObject(new Date(2021, 0, 4))
+  const obj = date.toObject()
+
+  t.is(obj.week, 1, 'Should be ISO week 1')
+  t.is(obj.year, 2021, 'Should be ISO year 2021')
+})
+
+test('toObject round-trips correctly through fromObject at year boundaries', (t) => {
+  // This is the critical data flow: toObject() -> fromObject() must be consistent
+  const original = new DateObject().fromObject({ year: 2026, week: 1 })
+  const { week, year } = original.toObject()
+  const reconstructed = new DateObject().fromObject({ week, year })
+
+  t.is(
+    reconstructed.jsDate.getTime(),
+    original.jsDate.getTime(),
+    'Round-trip through toObject/fromObject should produce the same date'
+  )
+})
+
+test('toObject round-trips correctly for week 53 of 2020', (t) => {
+  const original = new DateObject().fromObject({ year: 2020, week: 53 })
+  const { week, year } = original.toObject()
+  const reconstructed = new DateObject().fromObject({ week, year })
+
+  t.is(week, 53)
+  t.is(year, 2020)
+  t.is(
+    reconstructed.jsDate.getTime(),
+    original.jsDate.getTime(),
+    'Round-trip through toObject/fromObject should produce the same date'
+  )
+})

--- a/shared/utils/DateObject.ts
+++ b/shared/utils/DateObject.ts
@@ -226,10 +226,11 @@ export class DateObject {
    * @param include - Properties to include
    */
   public toObject(...include: string[]) {
+    const { isoWeek, isoYear } = DateUtils.getIsoWeekAndYear(this.$)
     const dateObject = {
-      week: DateUtils.getWeek(this.$),
+      week: isoWeek,
       month: DateUtils.getMonthIndex(this.$),
-      year: DateUtils.getYear(this.$),
+      year: isoYear,
       monthName: this.format('MMMM')
     }
     return _.isEmpty(include) ? dateObject : _.pick(dateObject, ...include)


### PR DESCRIPTION
### Description of the change

The implementation corrects the inconsistency in the `toObject` method, ensuring that the ISO week and year are accurately reflected in the summary report.  
This addresses the issue where the wrong year (2020) was displayed while the hours were from 2021. The changes include additional tests to verify the correct behavior at year boundaries.

### Related issue(s)

Fixes #1027

