### PR TITLE
fix: critical QA findings — auth, data, and client stability

### DIFF
--- a/client/pages/Home/useHome.ts
+++ b/client/pages/Home/useHome.ts
@@ -15,9 +15,13 @@ export function useHome(paramName = 'client_response') {
   const { user, subscription } = useAppContext()
   const location = useLocation<{ prevPath: string }>()
   const urlSearchParameters = new URLSearchParams(document.location.search)
-  const loginError: ISigninError =
-    urlSearchParameters.get(paramName) &&
-    JSON.parse(atob(urlSearchParameters.get(paramName) as string))
+  let loginError: ISigninError = null
+  try {
+    const raw = urlSearchParameters.get(paramName)
+    if (raw) loginError = JSON.parse(atob(raw))
+  } catch {
+    // Malformed URL parameter — ignore rather than crash
+  }
 
   useLoginRedirect(loginError)
 

--- a/client/pages/Reports/CustomQueryTab/useCustomQueryFilterCriterias.ts
+++ b/client/pages/Reports/CustomQueryTab/useCustomQueryFilterCriterias.ts
@@ -23,16 +23,20 @@ export const useCustomQueryFilterCriterias = (param: string, id: string) => {
   >()
 
   useEffect(() => {
-    const [, f] = id.split('_')
-    if (f) {
+    try {
+      const [, f] = id.split('_')
+      if (f) {
+        filterCriterias.$set(
+          new Map(Object.entries(JSON.parse(window.atob(f))) as any)
+        )
+        return
+      }
       filterCriterias.$set(
-        new Map(Object.entries(JSON.parse(window.atob(f))) as any)
+        new Map(Object.entries(getUrlState(param, 'hash', true))) as any
       )
-      return
+    } catch {
+      // Malformed URL state — leave filter criteria empty rather than crash
     }
-    filterCriterias.$set(
-      new Map(Object.entries(getUrlState(param, 'hash', true))) as any
-    )
   }, [id])
 
   useEffect(() => {

--- a/client/utils/getUrlState.ts
+++ b/client/utils/getUrlState.ts
@@ -32,14 +32,18 @@ export function getUrlState<T = any>(
   location: 'hash' | 'search',
   obj = false
 ): T {
-  if (location === 'hash') {
-    const urlState = parseUrlHash()
-    const value = urlState[key]
+  try {
+    if (location === 'hash') {
+      const urlState = parseUrlHash()
+      const value = urlState[key]
+      if (!obj) return value as T
+      return value ? JSON.parse(window.atob(value)) : ({} as T)
+    }
+    const url = new URL(window.location.href)
+    const value = url.searchParams.get(key)
     if (!obj) return value as T
     return value ? JSON.parse(window.atob(value)) : ({} as T)
+  } catch {
+    return (obj ? {} : undefined) as T
   }
-  const url = new URL(window.location.href)
-  const value = url.searchParams.get(key)
-  if (!obj) return value as T
-  return value ? JSON.parse(window.atob(value)) : ({} as T)
 }

--- a/server/graphql/resolvers/timesheet/TimesheetResolver.ts
+++ b/server/graphql/resolvers/timesheet/TimesheetResolver.ts
@@ -116,7 +116,7 @@ export class TimesheetResolver {
     try {
       await this._timesheetSvc.submitPeriod({ ...options, period })
       return {
-        success: false,
+        success: true,
         error: null
       }
     } catch (error) {

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -98,10 +98,18 @@ export const authCallbackHandler =
           debug('Error logging in user: %s', error_.message)
           return response.render('index', { error: JSON.stringify(error_) })
         }
-        const redirectUrl =
+        let redirectUrl =
           request.session[REDIRECT_URL_PROPERTY] ||
           user['startPage'] ||
           '/timesheet'
+        // Restrict redirect to internal relative paths to prevent open redirect
+        if (
+          typeof redirectUrl !== 'string' ||
+          !redirectUrl.startsWith('/') ||
+          redirectUrl.startsWith('//')
+        ) {
+          redirectUrl = '/timesheet'
+        }
         return response.redirect(redirectUrl)
       })
     })(request, response, next)

--- a/server/services/mongo/graph_users.ts
+++ b/server/services/mongo/graph_users.ts
@@ -93,7 +93,19 @@ export class GraphUsersService extends MongoDocumentService<ActiveDirectoryUser>
         .find({ $text: { $search: safe } })
         .limit(limit)
         .sort({ score: { $meta: 'textScore' } })
-        .project({ score: { $meta: 'textScore' } })
+        .project({
+          score: { $meta: 'textScore' },
+          _id: 1,
+          id: 1,
+          displayName: 1,
+          givenName: 1,
+          surname: 1,
+          mail: 1,
+          jobTitle: 1,
+          mobilePhone: 1,
+          preferredLanguage: 1,
+          accountEnabled: 1
+        })
         .toArray()
       return users as ActiveDirectoryUser[]
     } catch (error) {


### PR DESCRIPTION
## Summary
Addresses the four highest-priority findings from the 2026-03-24 QA review:

- **Open redirect after OAuth login (P1)** — `server/routes/auth.ts` now validates `redirectUrl` to reject non-relative and protocol-relative paths, matching the existing guard in the session-injection route.
- **`submitPeriod` returns `success: false` on success (P2)** — Copy-paste bug in `TimesheetResolver.ts`; the success path now correctly returns `{ success: true }`.
- **AD user search returns empty results (P2)** — `graph_users.ts` projection was stripping all user fields; now explicitly includes all `ActiveDirectoryUser` fields alongside the text score.
- **Malformed URL state crashes Home/Reports pages (P2)** — Added try/catch in `getUrlState`, `useHome`, and `useCustomQueryFilterCriterias` so bad base64/JSON in URL params is silently ignored instead of throwing during render.

## Test plan
- [ ] Log in via OAuth with a `?redirectUrl=https://evil.com` param — should redirect to `/timesheet`, not external URL
- [ ] Submit a timesheet period and verify the mutation result shows `success: true`
- [ ] Search for users in the AD search autocomplete — results should display names and emails
- [ ] Navigate to Home/Reports with a garbled `client_response` or hash param — page should render without crashing