### PR TITLE
docs: fix Docker documentation errors

### DIFF
--- a/docker/DOCKER.md
+++ b/docker/DOCKER.md
@@ -1,11 +1,11 @@
 ## Docker Script
 
-Use `/scripts/docker.sh` for all Docker development operations:
+Use `./scripts/docker.sh` for all Docker development operations:
 
 ```bash
-/scripts/docker.sh              # Start containers (default)
-/scripts/docker.sh start --fresh  # Clean start with fresh volumes
-/scripts/docker.sh status       # Show config and container status
+./scripts/docker.sh              # Start containers (default)
+./scripts/docker.sh start --fresh  # Clean start with fresh volumes
+./scripts/docker.sh status       # Show config and container status
 ```
 ## Common Reset Recipes
 
@@ -23,7 +23,7 @@ docker builder du
 
 Run a safe cleanup that keeps active containers and volumes:
 ```bash
-/scripts/docker-maintenance.sh --days 7
+./scripts/docker-maintenance.sh --days 7
 ```
 
 Via npm:
@@ -33,7 +33,7 @@ npm run docker:maintenance -- --days 7
 
 Optional flags:
 ```bash
-/scripts/docker-maintenance.sh --aggressive --include-volumes --clean-dist
+./scripts/docker-maintenance.sh --aggressive --include-volumes --clean-dist
 ```
 
 Notes:
@@ -199,7 +199,7 @@ MongoDB can be pre-populated with tenant data for development:
      └── puzzlepart/
          ├── users.json
          ├── projects.json
-         └── timeentries.json
+         └── time_entries.json
    ```
 
 3. **Start services** - data will be imported automatically on first MongoDB startup:

--- a/docker/data/README.md
+++ b/docker/data/README.md
@@ -11,7 +11,7 @@ For example:
 - `craycon/users.json` — Imported to the `users` collection in the `craycon` database
 - `craycon/projects.json` — Imported to the `projects` collection in the `craycon` database
 - `craycon/customers.json` — Imported to the `customers` collection in the `craycon` database
-- `craycon/timeentries.json` — Imported to the `timeentries` collection in the `craycon` database
+- `craycon/time_entries.json` — Imported to the `time_entries` collection in the `craycon` database
 
 This structure helps organize data for multiple databases and ensures clarity when importing.
 
@@ -30,7 +30,7 @@ mongoexport --uri="mongodb+srv://user:pass@cluster.mongodb.net/database" --colle
 mongoexport --uri="mongodb+srv://user:pass@cluster.mongodb.net/database" --collection=customers --out=customers.json
 
 # Export time entries (optionally with query to limit data)
-mongoexport --uri="mongodb+srv://user:pass@cluster.mongodb.net/database" --collection=timeentries --query='{"date":{"$gte":{"$date":"2024-01-01T00:00:00.000Z"}}}' --out=timeentries.json
+mongoexport --uri="mongodb+srv://user:pass@cluster.mongodb.net/database" --collection=time_entries --query='{"date":{"$gte":{"$date":"2024-01-01T00:00:00.000Z"}}}' --out=time_entries.json
 ```
 
 ## Security Note

--- a/docker/sample-data/README.md
+++ b/docker/sample-data/README.md
@@ -3,7 +3,7 @@ this folder contains sample JSON files for seeding the `did` development databas
 These files are intended for local development and testing purposes only.
 They provide a basic dataset to work with when running the application in a local Docker environment.
 ## Usage
-Rename `sample-data` to `data`, then run `npm run docker:setup` to import the sample data into your local MongoDB instance.
+Rename `sample-data` to `data`, then start the Docker stack with `./scripts/docker.sh start` to import the sample data into your local MongoDB instance on first startup.
 The sample data includes:
 - Users
 - Projects


### PR DESCRIPTION
## Summary
Fixes documentation errors flagged in the QA review:

- **Script paths**: `DOCKER.md` referenced `/scripts/docker.sh` and `/scripts/docker-maintenance.sh` (root-absolute) — corrected to `./scripts/docker.sh` and `./scripts/docker-maintenance.sh` (relative)
- **Collection name mismatch**: `docker/data/README.md` and `DOCKER.md` referenced `timeentries` as the collection name, but the runtime uses `time_entries` (with underscore). Files imported via the docs examples would have created an unreachable collection.
- **Non-existent script**: `docker/sample-data/README.md` referenced `npm run docker:setup` which doesn't exist in `package.json` — replaced with the actual startup command (`./scripts/docker.sh start`)

## Test plan
- [ ] Verify all script paths in `docker/DOCKER.md` are copy-pasteable from a repo root checkout
- [ ] Verify `time_entries` collection name matches `server/services/mongo/time_entry.ts` and sample data filenames