### PR TITLE
fix: Apollo variable redaction, remove misleading API, tighten types

### DIFF
--- a/client/hooks/user/usePermissions.ts
+++ b/client/hooks/user/usePermissions.ts
@@ -42,7 +42,7 @@ export function usePermissions(
   const permissionIds = Object.keys(permissions) as PermissionScope[]
 
   return useMemo(() => {
-    let _permissions = { ...permissions }
+    let _permissions: Partial<Record<PermissionScope, IPermissionInfo>> = { ...permissions }
     if (scopeIds) {
       _permissions = _.pick(_permissions, scopeIds)
     }

--- a/server/graphql/setupGraphQL.ts
+++ b/server/graphql/setupGraphQL.ts
@@ -89,7 +89,7 @@ export const setupGraphQL = async (
       },
       plugins: [
         ApolloServerPluginUsageReporting({
-          sendVariableValues: { all: true },
+          sendVariableValues: { none: true },
           generateClientInfo,
           sendReportsImmediately: environment<boolean>(
             'APOLLO_SCHEMA_REPORTING_SEND_REPORTS_IMMEDIATELY',

--- a/shared/config/security/permissions.ts
+++ b/shared/config/security/permissions.ts
@@ -11,7 +11,7 @@ import { IPermissionInfo, PermissionScope } from './types'
  */
 export const getPermissions = (
   t: TFunction
-): Record<string, IPermissionInfo> => ({
+): Record<PermissionScope, IPermissionInfo> => ({
   [PermissionScope.ACCESS_TIMESHEET]: {
     name: t('permissions.accessTimesheet'),
     description: t('permissions.accessTimesheetDescription'),

--- a/shared/utils/DateObject.ts
+++ b/shared/utils/DateObject.ts
@@ -68,7 +68,6 @@ export class DateObject {
    * If week and year is not specified, today's date is used
    *
    * @param input - Object input
-   * @param startOf - Optional start of (e.g. year or isoWeek)
    */
   public fromObject(input: ObjectInput): DateObject {
     const year =

--- a/shared/utils/DateObject.ts
+++ b/shared/utils/DateObject.ts
@@ -70,16 +70,15 @@ export class DateObject {
    * @param input - Object input
    * @param startOf - Optional start of (e.g. year or isoWeek)
    */
-  public fromObject(input: ObjectInput, startOf: any = 'isoWeek'): DateObject {
+  public fromObject(input: ObjectInput): DateObject {
     const year =
       typeof input.year === 'string' ? Number.parseInt(input.year) : input.year
     const isoWeek =
       typeof input.week === 'string' ? Number.parseInt(input.week) : input.week
-    
+
     // Use proper ISO week calculation to get the correct date
     const weekStartDate = DateUtils.getIsoWeekStartDate(isoWeek, year)
-    this.$ = weekStartDate.$
-    if (startOf) this.$ = this.$.startOf('isoWeek')
+    this.$ = weekStartDate.$.startOf('isoWeek')
     return this
   }
 

--- a/shared/utils/holidayUtils.ts
+++ b/shared/utils/holidayUtils.ts
@@ -68,7 +68,7 @@ export class HolidayValidationError extends Error {
   constructor(
     message: string,
     public readonly field: string,
-    public readonly value: any
+    public readonly value: unknown
   ) {
     super(message)
     this.name = 'HolidayValidationError'


### PR DESCRIPTION
## Summary
Addresses remaining low-priority QA items 1, 3, and 4:

- **Apollo variable reporting (P3)**: Changed `sendVariableValues` from `{ all: true }` to `{ none: true }` in `setupGraphQL.ts`. This prevents PII and sensitive identifiers from being shipped to Apollo Studio when reporting is active.
- **`DateObject.fromObject()` misleading parameter**: Removed the unused `startOf` parameter — it was always hardcoded to `'isoWeek'` regardless of what was passed. No call sites used a non-default value.
- **Loose typing cleanup**:
  - `HolidayValidationError.value`: `any` → `unknown`
  - `getPermissions` return type: `Record<string, IPermissionInfo>` → `Record<PermissionScope, IPermissionInfo>`
  - `usePermissions` local variable typed as `Partial<Record<PermissionScope, ...>>` to accommodate `_.pick`

## Test plan
- [ ] Verify Apollo reporting still functions (if enabled) — variables should now be redacted
- [ ] Run existing `DateObject` tests — `fromObject` behavior is unchanged
- [ ] TypeScript compiles clean (`npx tsc --noEmit --project client/tsconfig.json`)