### PR TITLE
feat: personal access tokens

### DIFF
--- a/client/i18n/en-GB.json
+++ b/client/i18n/en-GB.json
@@ -782,6 +782,8 @@
     "roleUser": "User",
     "roleAdmin": "Administrator",
     "save": "Save",
+    "copied": "Copied!",
+    "copyToClipboard": "Click to copy",
     "titleLabel": "Title",
     "timeLabel": "Time",
     "durationLabel": "Duration",

--- a/client/i18n/en-GB.json
+++ b/client/i18n/en-GB.json
@@ -269,7 +269,11 @@
       "displaySecretKeyButtonLabel": "Show me the secret",
       "permissionsRequired": "You need to provide at least one permission for the API-key. No point in having a role if you can't do anything with it? It's like having a job with no tasks.",
       "tokenDescriptionDescription": "Describe briefly (minimum {{minLength}} characters) how you intend to use the API-token, and explain briefly why you need the selected permissions.",
-      "warningTooManyPermissions": "You've selected {{count}} permissions. We recommend not too be too greedy with permissions, but if you know what you're doing - sure."
+      "warningTooManyPermissions": "You've selected {{count}} permissions. We recommend not too be too greedy with permissions, but if you know what you're doing - sure.",
+      "tokenType": "Type",
+      "tokenTypeSubscription": "Subscription",
+      "tokenTypePersonal": "Personal",
+      "tokenOwner": "Owner"
     },
     "labels": {
       "confirmDeleteTitle": "Delete label",
@@ -310,7 +314,9 @@
       "enableSimpleHierachyLabel": "Enable Hierarchy",
       "enableSimpleHierachyDescription": "Enable project hierarchy supporting setting parent project, displaying parent and child projects.",
       "autoLoadTimeEntriesLabel": "Automatically Load Time Entries",
-      "autoLoadTimeEntriesDescription": "When enabled, time entries will be loaded automatically without requiring manual action."
+      "autoLoadTimeEntriesDescription": "When enabled, time entries will be loaded automatically without requiring manual action.",
+      "personalAccessTokensEnabledLabel": "Allow personal access tokens",
+      "personalAccessTokensEnabledDescription": "When enabled, users can create personal API tokens for scripting and automation."
     },
     "rolesPermissions": {
       "headerText": "Roles and permissions",
@@ -616,6 +622,24 @@
     "summaryDescription": "Get a tabular overview of time entries per employee and period.",
     "customQueryWeekDisabled": "You cannot filter by week while filtering on start date, end date or month.",
     "customQueryMonthDisabled": "You cannot filter by month while filtering on start date, end date or week."
+  },
+  "userSettings": {
+    "apiTokens": {
+      "tabTitle": "API tokens",
+      "emptyState": "You don't have any personal access tokens yet. Create one to access the API from scripts or integrations.",
+      "addNew": "Create token",
+      "delete": "Delete",
+      "tokenNameLabel": "Token name",
+      "tokenDescriptionDescription": "Describe what this token will be used for (minimum {{minLength}} characters).",
+      "tokenExpiryLabel": "Expiry",
+      "permissionsLabel": "Permissions",
+      "permissionsDescription": "Select which permissions this token should have. You can only grant permissions you currently have.",
+      "apiKeyGenerated": "Your new personal access token. Copy it now - you won't be able to see it again.",
+      "tokenCreated": "Personal access token created.",
+      "tokenDeleted": "Personal access token deleted.",
+      "deleteConfirmTitle": "Delete personal access token",
+      "deleteConfirmMessage": "Are you sure you want to delete the token \"{{name}}\"? Any integrations using this token will stop working."
+    }
   },
   "common": {
     "datePicker": {

--- a/client/i18n/nb.json
+++ b/client/i18n/nb.json
@@ -268,7 +268,11 @@
       "displaySecretKeyButtonLabel": "Vis meg nøkkelen",
       "permissionsRequired": "Du må velge minst én tillatelse for API-nøkkelen. Ingen vits i å ha en rolle hvis du ikke kan gjøre noe med den? Det er som å ha en jobb uten oppgaver.",
       "tokenDescriptionDescription": "Beskriv (minst {{minLength}} tegn) hvordan du har tenkt å bruke API-token, og forklar kort hvorfor du trenger de valgte tillatelsene.",
-      "warningTooManyPermissions": "Du har valgt {{count}} tillatelser. \nVi anbefaler ikke å være for grådig med tillatelser, men hvis du vet hva du gjør - kjør på."
+      "warningTooManyPermissions": "Du har valgt {{count}} tillatelser. \nVi anbefaler ikke å være for grådig med tillatelser, men hvis du vet hva du gjør - kjør på.",
+      "tokenType": "Type",
+      "tokenTypeSubscription": "Abonnement",
+      "tokenTypePersonal": "Personlig",
+      "tokenOwner": "Eier"
     },
     "users": {
       "headerText": "Brukere",
@@ -375,7 +379,9 @@
       "enableSimpleHierachyDescription": "Aktiver prosjekthierarki som støtter innstilling av overordnet prosjekt, visning av overordnede og underordnede prosjekter.",
       "enableSimpleHierachyLabel": "Aktiver hierarki",
       "autoLoadTimeEntriesLabel": "Last inn tidsoppføringer automatisk",
-      "autoLoadTimeEntriesDescription": "Når aktivert, lastes tidsoppføringer automatisk uten at du trenger å gjøre noe."
+      "autoLoadTimeEntriesDescription": "Når aktivert, lastes tidsoppføringer automatisk uten at du trenger å gjøre noe.",
+      "personalAccessTokensEnabledLabel": "Tillat personlige tilgangsnøkler",
+      "personalAccessTokensEnabledDescription": "Når aktivert kan brukere opprette personlige API-nøkler for skripting og automatisering."
     },
     "rolesPermissions": {
       "headerText": "Roller og tillatelser",
@@ -616,6 +622,24 @@
     "summaryDescription": "Få en tabelloversikt over tidsregistreringer per ansatt og periode.",
     "customQueryWeekDisabled": "Du kan ikke filtrere på uke samtidig som du filtrerer på startdato, sluttdato eller måned.",
     "customQueryMonthDisabled": "Du kan ikke filtrere på måned samtidig som du filtrerer på startdato, sluttdato eller uke."
+  },
+  "userSettings": {
+    "apiTokens": {
+      "tabTitle": "API-nøkler",
+      "emptyState": "Du har ingen personlige tilgangsnøkler ennå. Opprett en for å bruke API-et fra skript eller integrasjoner.",
+      "addNew": "Opprett nøkkel",
+      "delete": "Slett",
+      "tokenNameLabel": "Navn på nøkkel",
+      "tokenDescriptionDescription": "Beskriv hva denne nøkkelen skal brukes til (minimum {{minLength}} tegn).",
+      "tokenExpiryLabel": "Utløper",
+      "permissionsLabel": "Tillatelser",
+      "permissionsDescription": "Velg hvilke tillatelser denne nøkkelen skal ha. Du kan kun gi tillatelser du selv har.",
+      "apiKeyGenerated": "Din nye personlige tilgangsnøkkel. Kopier den nå - du vil ikke kunne se den igjen.",
+      "tokenCreated": "Personlig tilgangsnøkkel opprettet.",
+      "tokenDeleted": "Personlig tilgangsnøkkel slettet.",
+      "deleteConfirmTitle": "Slett personlig tilgangsnøkkel",
+      "deleteConfirmMessage": "Er du sikker på at du vil slette nøkkelen \"{{name}}\"? Integrasjoner som bruker denne nøkkelen vil slutte å fungere."
+    }
   },
   "common": {
     "datePicker": {

--- a/client/i18n/nb.json
+++ b/client/i18n/nb.json
@@ -782,6 +782,8 @@
     "roleUser": "Bruker",
     "roleAdmin": "Administrator",
     "save": "Lagre",
+    "copied": "Kopiert!",
+    "copyToClipboard": "Klikk for a kopiere",
     "titleLabel": "Tittel",
     "timeLabel": "Tidspunkt",
     "durationLabel": "Varighet",

--- a/client/i18n/nn.json
+++ b/client/i18n/nn.json
@@ -270,7 +270,11 @@
       "displaySecretKeyButtonLabel": "Vis meg nøkkelen",
       "displaySecretKeyButtonTooltip": "Klikk for å avsløre den hemmelig nøkkelen i {{displayDuration}} sekunder, og klikk deretter på feltene for å kopiere den.",
       "keyLabel": "Hemmelig nøkkel",
-      "yearPlural": "{{years}} år"
+      "yearPlural": "{{years}} år",
+      "tokenType": "Type",
+      "tokenTypeSubscription": "Abonnement",
+      "tokenTypePersonal": "Personleg",
+      "tokenOwner": "Eigar"
     },
     "users": {
       "headerText": "Brukarar",
@@ -375,7 +379,9 @@
       "enableSimpleHierachyLabel": "Aktiver hierarki",
       "enableSimpleHierachyDescription": "Aktiver prosjekthierarki som støtter innstilling av overordnet prosjekt, visning av overordnede og underordnede prosjekter.",
       "autoLoadTimeEntriesLabel": "Last inn tidsoppføringer automatisk",
-      "autoLoadTimeEntriesDescription": "Når aktivert, lastes tidsoppføringer automatisk uten at du trenger å gjøre noe."
+      "autoLoadTimeEntriesDescription": "Når aktivert, lastes tidsoppføringer automatisk uten at du trenger å gjøre noe.",
+      "personalAccessTokensEnabledLabel": "Tillat personlege tilgangsnøklar",
+      "personalAccessTokensEnabledDescription": "Når dette er aktivert, kan brukarar oppretta personlege API-nøklar for skript og automatisering."
     },
     "rolesPermissions": {
       "headerText": "Roller og tillatelser",
@@ -616,6 +622,24 @@
     "summaryDescription": "Få ei tabelloversikt over tidsregistreringar per tilsett og periode.",
     "customQueryWeekDisabled": "Du kan ikkje filtrere på veke samstundes som du filtrerer på startdato, sluttdato eller månad.",
     "customQueryMonthDisabled": "Du kan ikkje filtrere på månad samstundes som du filtrerer på startdato, sluttdato eller veke."
+  },
+  "userSettings": {
+    "apiTokens": {
+      "tabTitle": "API-nøklar",
+      "emptyState": "Du har ingen personlege tilgangsnøklar enno. Opprett ein for å få tilgang til API-et frå skript eller integrasjonar.",
+      "addNew": "Opprett nøkkel",
+      "delete": "Slett",
+      "tokenNameLabel": "Namn på nøkkel",
+      "tokenDescriptionDescription": "Skildre kva denne nøkkelen skal brukast til (minimum {{minLength}} teikn).",
+      "tokenExpiryLabel": "Utløp",
+      "permissionsLabel": "Tillatingar",
+      "permissionsDescription": "Vel kva tillatingar denne nøkkelen skal ha. Du kan berre gi tillatingar du sjølv har.",
+      "apiKeyGenerated": "Den nye personlege tilgangsnøkkelen din. Kopier han no - du vil ikkje kunna sjå han igjen.",
+      "tokenCreated": "Personleg tilgangsnøkkel oppretta.",
+      "tokenDeleted": "Personleg tilgangsnøkkel sletta.",
+      "deleteConfirmTitle": "Slett personleg tilgangsnøkkel",
+      "deleteConfirmMessage": "Er du sikker på at du vil sletta nøkkelen \"{{name}}\"? Alle integrasjonar som brukar denne nøkkelen vil slutta å fungera."
+    }
   },
   "common": {
     "datePicker": {

--- a/client/pages/Admin/ApiTokens/deleteApiToken.gql
+++ b/client/pages/Admin/ApiTokens/deleteApiToken.gql
@@ -1,5 +1,5 @@
-mutation DeleteApiToken ($name: String!) {
-  result: deleteApiToken(name: $name) {
+mutation DeleteApiToken ($name: String!, $type: String, $userId: String) {
+  result: deleteApiToken(name: $name, type: $type, userId: $userId) {
     success
     error {
       message

--- a/client/pages/Admin/ApiTokens/tokens.gql
+++ b/client/pages/Admin/ApiTokens/tokens.gql
@@ -5,5 +5,7 @@ query ApiTokens {
       created
       expires
       secret: apiKey
+      type
+      userId
     }
   }

--- a/client/pages/Admin/ApiTokens/useApiTokens.tsx
+++ b/client/pages/Admin/ApiTokens/useApiTokens.tsx
@@ -43,7 +43,13 @@ export function useApiTokens() {
       ]
     })
     if (!response) return
-    await deleteApiToken({ variables: { name: selectedToken.name } })
+    await deleteApiToken({
+      variables: {
+        name: selectedToken.name,
+        type: selectedToken.type || 'subscription',
+        userId: selectedToken.userId
+      }
+    })
     displayToast(t('admin.tokenDeletedText', selectedToken), 'success')
     refetch()
   }, [selectedToken])

--- a/client/pages/Admin/ApiTokens/useColumns.tsx
+++ b/client/pages/Admin/ApiTokens/useColumns.tsx
@@ -22,6 +22,18 @@ export function useColumns(
       minWidth: 100,
       maxWidth: 100
     }),
+    createColumnDef<ApiToken>(
+      'type',
+      t('admin.apiTokens.tokenType'),
+      {
+        minWidth: 80,
+        maxWidth: 100
+      },
+      (token) =>
+        token.type === 'personal'
+          ? t('admin.apiTokens.tokenTypePersonal')
+          : t('admin.apiTokens.tokenTypeSubscription')
+    ),
     createColumnDef('description', t('common.descriptionFieldLabel'), {
       minWidth: 180,
       maxWidth: 220,

--- a/client/pages/Admin/ApiTokens/useColumns.tsx
+++ b/client/pages/Admin/ApiTokens/useColumns.tsx
@@ -58,13 +58,14 @@ export function useColumns(
           minWidth: 100,
           maxWidth: 180
         },
-        (token) => (
-          <ApiKeyDisplay
-            toggleDisplay
-            apiKey={token['secret']}
-            onKeyCopied={() => onKeyCopied(token)}
-          />
-        )
+        (token) =>
+          token.type === 'personal' ? null : (
+            <ApiKeyDisplay
+              toggleDisplay
+              apiKey={token['secret']}
+              onKeyCopied={() => onKeyCopied(token)}
+            />
+          )
       )
   ].filter(Boolean)
 }

--- a/client/pages/Admin/SubscriptionSettings/useSubscriptionConfig.ts
+++ b/client/pages/Admin/SubscriptionSettings/useSubscriptionConfig.ts
@@ -258,6 +258,19 @@ export function useSubscriptionConfig() {
             placeholder: t('admin.domainRestrictionExternalPlaceholder'),
             contentBefore: '@'
           }
+        },
+        {
+          id: 'personalAccessTokensEnabled',
+          type: 'bool',
+          props: {
+            label: t(
+              'admin.subscriptionSettings.personalAccessTokensEnabledLabel'
+            ),
+            description: t(
+              'admin.subscriptionSettings.personalAccessTokensEnabledDescription'
+            ),
+            defaultValue: true
+          }
         }
       ]
     },

--- a/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/ApiTokens.tsx
+++ b/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/ApiTokens.tsx
@@ -1,6 +1,6 @@
 import { Button, Input, Label, MessageBar } from '@fluentui/react-components'
 import { Copy20Regular, Checkmark20Regular } from '@fluentui/react-icons'
-import { SelectionMode } from 'components/List/types'
+import { CheckboxVisibility, SelectionMode } from 'components/List/types'
 import { List, ListMenuItem } from 'components'
 import React, { useState } from 'react'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
@@ -76,6 +76,7 @@ export const ApiTokensTab: React.FC = () => {
         columns={columns}
         items={items}
         autoFitColumns={false}
+        checkboxVisibility={CheckboxVisibility.hidden}
         selectionProps={[SelectionMode.single, onSelectionChanged]}
         menuItems={[
           new ListMenuItem(t('userSettings.apiTokens.addNew'))

--- a/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/ApiTokens.tsx
+++ b/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/ApiTokens.tsx
@@ -1,9 +1,10 @@
+import { Input, Label, MessageBar, Text } from '@fluentui/react-components'
 import { SelectionMode } from 'components/List/types'
 import { List, ListMenuItem } from 'components'
 import React, { useState } from 'react'
+import { CopyToClipboard } from 'react-copy-to-clipboard'
 import { useTranslation } from 'react-i18next'
 import { createColumnDef } from 'utils'
-import { ApiKeyDisplay } from 'pages/Admin/ApiTokens/ApiKeyDisplay'
 import { PersonalAccessTokenForm } from './PersonalAccessTokenForm'
 import { usePersonalAccessTokens } from './usePersonalAccessTokens'
 
@@ -14,22 +15,17 @@ export const ApiTokensTab: React.FC = () => {
     newToken,
     onTokenAdded,
     onDelete,
-    onKeyCopied,
     onSelectionChanged,
     selectedToken,
     confirmationDialog
   } = usePersonalAccessTokens()
   const [formOpen, setFormOpen] = useState(false)
+  const [copied, setCopied] = useState(false)
 
   const columns = [
     createColumnDef('name', t('userSettings.apiTokens.tokenNameLabel'), {
       minWidth: 100,
-      maxWidth: 150
-    }),
-    createColumnDef('description', t('common.descriptionFieldLabel'), {
-      minWidth: 150,
-      maxWidth: 250,
-      isMultiline: true
+      maxWidth: 180
     }),
     createColumnDef('created', t('common.createdLabel'), {
       minWidth: 100,
@@ -45,11 +41,30 @@ export const ApiTokensTab: React.FC = () => {
 
   return (
     <div>
-      <ApiKeyDisplay
-        label={t('userSettings.apiTokens.apiKeyGenerated')}
-        apiKey={newToken?.apiKey}
-        onKeyCopied={() => onKeyCopied()}
-      />
+      {newToken?.apiKey && (
+        <MessageBar intent='success' style={{ marginBottom: 12 }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, width: '100%' }}>
+            <Label weight='semibold'>
+              {t('userSettings.apiTokens.apiKeyGenerated')}
+            </Label>
+            <CopyToClipboard
+              text={newToken.apiKey}
+              onCopy={() => setCopied(true)}
+            >
+              <Input
+                readOnly
+                value={newToken.apiKey}
+                style={{ width: '100%', cursor: 'pointer', fontFamily: 'monospace', fontSize: 12 }}
+              />
+            </CopyToClipboard>
+            <Text size={200}>
+              {copied
+                ? t('admin.apiTokens.apiKeyCopied', newToken)
+                : t('userSettings.apiTokens.apiKeyGenerated')}
+            </Text>
+          </div>
+        </MessageBar>
+      )}
       {items.length === 0 && !newToken && !formOpen && (
         <p>{t('userSettings.apiTokens.emptyState')}</p>
       )}
@@ -73,10 +88,10 @@ export const ApiTokensTab: React.FC = () => {
           open={formOpen}
           onTokenAdded={(token) => {
             setFormOpen(false)
+            setCopied(false)
             onTokenAdded(token)
           }}
           onDismiss={() => setFormOpen(false)}
-          tokens={items}
         />
       )}
       {confirmationDialog}

--- a/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/ApiTokens.tsx
+++ b/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/ApiTokens.tsx
@@ -71,6 +71,7 @@ export const ApiTokensTab: React.FC = () => {
       <List
         columns={columns}
         items={items}
+        autoFitColumns={false}
         selectionProps={[SelectionMode.single, onSelectionChanged]}
         menuItems={[
           new ListMenuItem(t('userSettings.apiTokens.addNew'))

--- a/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/ApiTokens.tsx
+++ b/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/ApiTokens.tsx
@@ -1,0 +1,87 @@
+import { SelectionMode } from 'components/List/types'
+import { List, ListMenuItem } from 'components'
+import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { createColumnDef } from 'utils'
+import { ApiKeyDisplay } from 'pages/Admin/ApiTokens/ApiKeyDisplay'
+import { PersonalAccessTokenForm } from './PersonalAccessTokenForm'
+import { usePersonalAccessTokens } from './usePersonalAccessTokens'
+
+export const ApiTokensTab: React.FC = () => {
+  const { t } = useTranslation()
+  const {
+    items,
+    newToken,
+    onTokenAdded,
+    onDelete,
+    onKeyCopied,
+    onSelectionChanged,
+    selectedToken,
+    confirmationDialog
+  } = usePersonalAccessTokens()
+  const [formOpen, setFormOpen] = useState(false)
+
+  const columns = [
+    createColumnDef('name', t('userSettings.apiTokens.tokenNameLabel'), {
+      minWidth: 100,
+      maxWidth: 150
+    }),
+    createColumnDef('description', t('common.descriptionFieldLabel'), {
+      minWidth: 150,
+      maxWidth: 250,
+      isMultiline: true
+    }),
+    createColumnDef('created', t('common.createdLabel'), {
+      minWidth: 100,
+      maxWidth: 150,
+      renderAs: 'timeFromNow'
+    }),
+    createColumnDef('expires', t('common.expiresLabel'), {
+      minWidth: 100,
+      maxWidth: 150,
+      renderAs: 'timeFromNow'
+    })
+  ]
+
+  return (
+    <div>
+      <ApiKeyDisplay
+        label={t('userSettings.apiTokens.apiKeyGenerated')}
+        apiKey={newToken?.apiKey}
+        onKeyCopied={() => onKeyCopied()}
+      />
+      {items.length === 0 && !newToken && !formOpen && (
+        <p>{t('userSettings.apiTokens.emptyState')}</p>
+      )}
+      <List
+        columns={columns}
+        items={items}
+        selectionProps={[SelectionMode.single, onSelectionChanged]}
+        menuItems={[
+          new ListMenuItem(t('userSettings.apiTokens.addNew'))
+            .withIcon('Add')
+            .setOnClick(() => setFormOpen(true)),
+          new ListMenuItem(t('userSettings.apiTokens.delete'))
+            .setOnClick(onDelete)
+            .withIcon('Delete')
+            .setGroup('actions')
+            .setDisabled(!selectedToken)
+        ]}
+      />
+      {formOpen && (
+        <PersonalAccessTokenForm
+          open={formOpen}
+          onTokenAdded={(token) => {
+            setFormOpen(false)
+            onTokenAdded(token)
+          }}
+          onDismiss={() => setFormOpen(false)}
+          tokens={items}
+        />
+      )}
+      {confirmationDialog}
+    </div>
+  )
+}
+
+ApiTokensTab.displayName = 'ApiTokensTab'

--- a/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/ApiTokens.tsx
+++ b/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/ApiTokens.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, Label, MessageBar, Text } from '@fluentui/react-components'
+import { Button, Input, Label, MessageBar } from '@fluentui/react-components'
 import { Copy20Regular, Checkmark20Regular } from '@fluentui/react-icons'
 import { SelectionMode } from 'components/List/types'
 import { List, ListMenuItem } from 'components'
@@ -25,12 +25,12 @@ export const ApiTokensTab: React.FC = () => {
 
   const columns = [
     createColumnDef('name', t('userSettings.apiTokens.tokenNameLabel'), {
-      minWidth: 60,
-      maxWidth: 120
+      minWidth: 110,
+      maxWidth: 170
     }),
     createColumnDef('created', t('common.createdLabel'), {
-      minWidth: 60,
-      maxWidth: 100,
+      minWidth: 160,
+      maxWidth: 200,
       renderAs: 'timeFromNow'
     }),
     createColumnDef('expires', t('common.expiresLabel'), {

--- a/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/ApiTokens.tsx
+++ b/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/ApiTokens.tsx
@@ -1,4 +1,5 @@
-import { Input, Label, MessageBar, Text } from '@fluentui/react-components'
+import { Button, Input, Label, MessageBar, Text } from '@fluentui/react-components'
+import { Copy20Regular, Checkmark20Regular } from '@fluentui/react-icons'
 import { SelectionMode } from 'components/List/types'
 import { List, ListMenuItem } from 'components'
 import React, { useState } from 'react'
@@ -42,26 +43,29 @@ export const ApiTokensTab: React.FC = () => {
   return (
     <div style={{ overflow: 'hidden' }}>
       {newToken?.apiKey && (
-        <MessageBar intent='success' style={{ marginBottom: 12 }}>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, minWidth: 0 }}>
+        <MessageBar intent={copied ? 'success' : 'warning'} style={{ marginBottom: 12 }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10, minWidth: 0 }}>
             <Label weight='semibold'>
               {t('userSettings.apiTokens.apiKeyGenerated')}
             </Label>
+            <Input
+              readOnly
+              value={newToken.apiKey}
+              style={{ fontFamily: 'monospace', fontSize: 12 }}
+            />
             <CopyToClipboard
               text={newToken.apiKey}
               onCopy={() => setCopied(true)}
             >
-              <Input
-                readOnly
-                value={newToken.apiKey}
-                style={{ cursor: 'pointer', fontFamily: 'monospace', fontSize: 12 }}
-              />
+              <Button
+                appearance={copied ? 'subtle' : 'primary'}
+                icon={copied ? <Checkmark20Regular /> : <Copy20Regular />}
+                size='large'
+                style={{ width: '100%' }}
+              >
+                {copied ? t('common.copied') : t('common.copyToClipboard')}
+              </Button>
             </CopyToClipboard>
-            <Text size={200}>
-              {copied
-                ? t('admin.apiTokens.apiKeyCopied', newToken)
-                : t('userSettings.apiTokens.apiKeyGenerated')}
-            </Text>
           </div>
         </MessageBar>
       )}

--- a/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/ApiTokens.tsx
+++ b/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/ApiTokens.tsx
@@ -24,26 +24,26 @@ export const ApiTokensTab: React.FC = () => {
 
   const columns = [
     createColumnDef('name', t('userSettings.apiTokens.tokenNameLabel'), {
-      minWidth: 100,
-      maxWidth: 180
+      minWidth: 60,
+      maxWidth: 120
     }),
     createColumnDef('created', t('common.createdLabel'), {
-      minWidth: 100,
-      maxWidth: 150,
+      minWidth: 60,
+      maxWidth: 100,
       renderAs: 'timeFromNow'
     }),
     createColumnDef('expires', t('common.expiresLabel'), {
-      minWidth: 100,
-      maxWidth: 150,
+      minWidth: 60,
+      maxWidth: 100,
       renderAs: 'timeFromNow'
     })
   ]
 
   return (
-    <div>
+    <div style={{ overflow: 'hidden' }}>
       {newToken?.apiKey && (
         <MessageBar intent='success' style={{ marginBottom: 12 }}>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, width: '100%' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, minWidth: 0 }}>
             <Label weight='semibold'>
               {t('userSettings.apiTokens.apiKeyGenerated')}
             </Label>
@@ -54,7 +54,7 @@ export const ApiTokensTab: React.FC = () => {
               <Input
                 readOnly
                 value={newToken.apiKey}
-                style={{ width: '100%', cursor: 'pointer', fontFamily: 'monospace', fontSize: 12 }}
+                style={{ cursor: 'pointer', fontFamily: 'monospace', fontSize: 12 }}
               />
             </CopyToClipboard>
             <Text size={200}>

--- a/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/PersonalAccessTokenForm.tsx
+++ b/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/PersonalAccessTokenForm.tsx
@@ -5,19 +5,18 @@ import {
   DropdownControlOptions,
   FormControl,
   InputControl,
+  ValidatorFunction,
   useFormControlModel,
   useFormControls
 } from 'components/FormControl'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyledComponent } from 'types'
+import { ApiToken, ApiTokenInput, StyledComponent } from 'types'
 import { fuzzyMap } from 'utils'
 import { EditPermissions } from 'pages/Admin/RolesPermissions'
 import { useExpiryOptions } from 'pages/Admin/ApiTokens/ApiTokenForm/useExpiryOptions'
-import { ApiTokenInput } from 'types'
 import { useMutation } from '@apollo/client'
 import { useAppContext } from 'AppContext'
-import { ApiToken } from 'types'
 import $addPersonalAccessToken from './addPersonalAccessToken.gql'
 
 interface IPersonalAccessTokenFormProps {
@@ -99,11 +98,10 @@ export const PersonalAccessTokenForm: StyledComponent<
       <EditPermissions
         {...register<BaseControlOptions>('permissions', {
           validators: [
-            {
-              state: 'invalid',
-              func: (v: string[]) => !v || v.length === 0,
-              message: t('admin.apiTokens.permissionsRequired')
-            }
+            ((value: string[]) =>
+              !value || value.length === 0
+                ? [t('admin.apiTokens.permissionsRequired'), 'error']
+                : null) as ValidatorFunction<string[]>
           ]
         })}
         label={t('userSettings.apiTokens.permissionsLabel')}

--- a/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/PersonalAccessTokenForm.tsx
+++ b/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/PersonalAccessTokenForm.tsx
@@ -42,8 +42,12 @@ export const PersonalAccessTokenForm: StyledComponent<
     text: t('common.save'),
     onClick: async () => {
       try {
+        const token = {
+          ...model.$,
+          expires: new DateObject().add(model.value('expires')).jsDate
+        }
         const { data } = await addToken({
-          variables: { token: model.$ }
+          variables: { token }
         })
         const created = { ...(model.$ as ApiToken), ...data }
         model.reset()
@@ -72,9 +76,7 @@ export const PersonalAccessTokenForm: StyledComponent<
       />
       <DropdownControl
         {...register<DropdownControlOptions>('expires', {
-          required: true,
-          preTransformValue: ({ optionValue }) =>
-            new DateObject().add(optionValue).jsDate
+          required: true
         })}
         label={t('userSettings.apiTokens.tokenExpiryLabel')}
         values={fuzzyMap<any>(expiryOptions, (value, key) => ({

--- a/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/PersonalAccessTokenForm.tsx
+++ b/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/PersonalAccessTokenForm.tsx
@@ -23,7 +23,6 @@ interface IPersonalAccessTokenFormProps {
   open: boolean
   onTokenAdded: (token: ApiToken) => void
   onDismiss: () => void
-  tokens: ApiToken[]
 }
 
 export const PersonalAccessTokenForm: StyledComponent<
@@ -46,7 +45,6 @@ export const PersonalAccessTokenForm: StyledComponent<
         const { data } = await addToken({
           variables: { token: model.$ }
         })
-        displayToast(t('userSettings.apiTokens.tokenCreated'), 'success', 20)
         const created = { ...(model.$ as ApiToken), ...data }
         model.reset()
         props.onTokenAdded(created)
@@ -71,17 +69,6 @@ export const PersonalAccessTokenForm: StyledComponent<
       <InputControl
         {...register('name', { required: true })}
         label={t('userSettings.apiTokens.tokenNameLabel')}
-      />
-      <InputControl
-        {...register('description', {
-          required: true,
-          validators: [{ minLength: 20 }]
-        })}
-        rows={8}
-        label={t('common.descriptionFieldLabel')}
-        description={t('userSettings.apiTokens.tokenDescriptionDescription', {
-          minLength: 20
-        })}
       />
       <DropdownControl
         {...register<DropdownControlOptions>('expires', {

--- a/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/PersonalAccessTokenForm.tsx
+++ b/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/PersonalAccessTokenForm.tsx
@@ -1,0 +1,120 @@
+import { DateObject } from 'DateUtils'
+import {
+  BaseControlOptions,
+  DropdownControl,
+  DropdownControlOptions,
+  FormControl,
+  InputControl,
+  useFormControlModel,
+  useFormControls
+} from 'components/FormControl'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyledComponent } from 'types'
+import { fuzzyMap } from 'utils'
+import { EditPermissions } from 'pages/Admin/RolesPermissions'
+import { useExpiryOptions } from 'pages/Admin/ApiTokens/ApiTokenForm/useExpiryOptions'
+import { ApiTokenInput } from 'types'
+import { useMutation } from '@apollo/client'
+import { useAppContext } from 'AppContext'
+import { ApiToken } from 'types'
+import $addPersonalAccessToken from './addPersonalAccessToken.gql'
+
+interface IPersonalAccessTokenFormProps {
+  open: boolean
+  onTokenAdded: (token: ApiToken) => void
+  onDismiss: () => void
+  tokens: ApiToken[]
+}
+
+export const PersonalAccessTokenForm: StyledComponent<
+  IPersonalAccessTokenFormProps
+> = (props) => {
+  const { t } = useTranslation()
+  const model = useFormControlModel<keyof ApiTokenInput>()
+  const register = useFormControls<keyof ApiTokenInput>(
+    model,
+    PersonalAccessTokenForm
+  )
+  const expiryOptions = useExpiryOptions()
+  const [addToken] = useMutation($addPersonalAccessToken)
+  const { displayToast } = useAppContext()
+
+  const submitProps = {
+    text: t('common.save'),
+    onClick: async () => {
+      try {
+        const { data } = await addToken({
+          variables: { token: model.$ }
+        })
+        displayToast(t('userSettings.apiTokens.tokenCreated'), 'success', 20)
+        const created = { ...(model.$ as ApiToken), ...data }
+        model.reset()
+        props.onTokenAdded(created)
+      } catch {
+        displayToast(t('common.errorText'), 'error')
+        props.onDismiss()
+      }
+    }
+  }
+
+  return (
+    <FormControl
+      id={PersonalAccessTokenForm.displayName}
+      model={model}
+      submitProps={submitProps}
+      panel={{
+        title: t('userSettings.apiTokens.addNew'),
+        open: props.open,
+        onDismiss: props.onDismiss
+      }}
+    >
+      <InputControl
+        {...register('name', { required: true })}
+        label={t('userSettings.apiTokens.tokenNameLabel')}
+      />
+      <InputControl
+        {...register('description', {
+          required: true,
+          validators: [{ minLength: 20 }]
+        })}
+        rows={8}
+        label={t('common.descriptionFieldLabel')}
+        description={t('userSettings.apiTokens.tokenDescriptionDescription', {
+          minLength: 20
+        })}
+      />
+      <DropdownControl
+        {...register<DropdownControlOptions>('expires', {
+          required: true,
+          preTransformValue: ({ optionValue }) =>
+            new DateObject().add(optionValue).jsDate
+        })}
+        label={t('userSettings.apiTokens.tokenExpiryLabel')}
+        values={fuzzyMap<any>(expiryOptions, (value, key) => ({
+          value: key,
+          text: value
+        }))}
+      />
+      <EditPermissions
+        {...register<BaseControlOptions>('permissions', {
+          validators: [
+            {
+              state: 'invalid',
+              func: (v: string[]) => !v || v.length === 0,
+              message: t('admin.apiTokens.permissionsRequired')
+            }
+          ]
+        })}
+        label={t('userSettings.apiTokens.permissionsLabel')}
+        description={t('userSettings.apiTokens.permissionsDescription')}
+        selectedPermissions={model.value('permissions')}
+        onChange={(selectedPermissions) =>
+          model.set('permissions', selectedPermissions)
+        }
+      />
+    </FormControl>
+  )
+}
+
+PersonalAccessTokenForm.displayName = 'PersonalAccessTokenForm'

--- a/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/addPersonalAccessToken.gql
+++ b/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/addPersonalAccessToken.gql
@@ -1,0 +1,3 @@
+mutation AddPersonalAccessToken($token: ApiTokenInput!) {
+  apiKey: addPersonalAccessToken(token: $token)
+}

--- a/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/deletePersonalAccessToken.gql
+++ b/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/deletePersonalAccessToken.gql
@@ -1,0 +1,8 @@
+mutation DeletePersonalAccessToken($name: String!) {
+  result: deletePersonalAccessToken(name: $name) {
+    success
+    error {
+      message
+    }
+  }
+}

--- a/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/index.ts
+++ b/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/index.ts
@@ -1,0 +1,1 @@
+export { ApiTokensTab } from './ApiTokens'

--- a/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/personalAccessTokens.gql
+++ b/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/personalAccessTokens.gql
@@ -4,6 +4,5 @@ query PersonalAccessTokens {
     description
     created
     expires
-    secret: apiKey
   }
 }

--- a/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/personalAccessTokens.gql
+++ b/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/personalAccessTokens.gql
@@ -1,0 +1,9 @@
+query PersonalAccessTokens {
+  tokens: personalAccessTokens {
+    name
+    description
+    created
+    expires
+    secret: apiKey
+  }
+}

--- a/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/usePersonalAccessTokens.ts
+++ b/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/usePersonalAccessTokens.ts
@@ -5,7 +5,6 @@ import { useConfirmationDialog } from 'pzl-react-reusable-components/lib/Confirm
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ApiToken } from 'types'
-import $addPersonalAccessToken from './addPersonalAccessToken.gql'
 import $deletePersonalAccessToken from './deletePersonalAccessToken.gql'
 import $personalAccessTokens from './personalAccessTokens.gql'
 
@@ -18,27 +17,22 @@ export function usePersonalAccessTokens() {
   )
   const items: ApiToken[] = data?.tokens ?? []
 
-  const [addToken] = useMutation($addPersonalAccessToken)
   const [deleteToken] = useMutation($deletePersonalAccessToken)
   const [newToken, setNewToken] = useState<ApiToken>(null)
   const [selectedToken, onSelectionChanged] = useState<ApiToken>(null)
   const [confirmationDialog, getResponse] = useConfirmationDialog()
 
   const onTokenAdded = useCallback(
-    async (token: ApiToken) => {
-      try {
-        const { data } = await addToken({ variables: { token } })
-        const created = { ...token, apiKey: data.apiKey }
-        setNewToken(created)
-        displayToast(t('userSettings.apiTokens.tokenCreated'), 'success')
-        refetch()
-        setTimeout(() => setNewToken(null), 10_000)
-      } catch (error) {
-        displayToast(error.message, 'error')
-      }
+    (token: ApiToken) => {
+      setNewToken(token)
+      refetch()
     },
-    [addToken, refetch]
+    [refetch]
   )
+
+  const clearNewToken = useCallback(() => {
+    setNewToken(null)
+  }, [])
 
   const onDelete = useCallback(async () => {
     const { response } = await getResponse({
@@ -59,18 +53,14 @@ export function usePersonalAccessTokens() {
     refetch()
   }, [selectedToken])
 
-  const onKeyCopied = useCallback(() => {
-    setNewToken(null)
-  }, [])
-
   return {
     items,
     newToken,
+    clearNewToken,
     selectedToken,
     onSelectionChanged,
     onTokenAdded,
     onDelete,
-    onKeyCopied,
     confirmationDialog
   }
 }

--- a/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/usePersonalAccessTokens.ts
+++ b/client/parts/UserMenu/UserSettings/Tabs/ApiTokens/usePersonalAccessTokens.ts
@@ -1,0 +1,76 @@
+import { useMutation, useQuery } from '@apollo/client'
+import { useAppContext } from 'AppContext'
+import { DateObject } from 'DateUtils'
+import { useConfirmationDialog } from 'pzl-react-reusable-components/lib/ConfirmDialog'
+import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ApiToken } from 'types'
+import $addPersonalAccessToken from './addPersonalAccessToken.gql'
+import $deletePersonalAccessToken from './deletePersonalAccessToken.gql'
+import $personalAccessTokens from './personalAccessTokens.gql'
+
+export function usePersonalAccessTokens() {
+  const { t } = useTranslation()
+  const { displayToast } = useAppContext()
+  const { data, refetch } = useQuery<{ tokens: ApiToken[] }>(
+    $personalAccessTokens,
+    { fetchPolicy: 'cache-and-network' }
+  )
+  const items: ApiToken[] = data?.tokens ?? []
+
+  const [addToken] = useMutation($addPersonalAccessToken)
+  const [deleteToken] = useMutation($deletePersonalAccessToken)
+  const [newToken, setNewToken] = useState<ApiToken>(null)
+  const [selectedToken, onSelectionChanged] = useState<ApiToken>(null)
+  const [confirmationDialog, getResponse] = useConfirmationDialog()
+
+  const onTokenAdded = useCallback(
+    async (token: ApiToken) => {
+      try {
+        const { data } = await addToken({ variables: { token } })
+        const created = { ...token, apiKey: data.apiKey }
+        setNewToken(created)
+        displayToast(t('userSettings.apiTokens.tokenCreated'), 'success')
+        refetch()
+        setTimeout(() => setNewToken(null), 10_000)
+      } catch (error) {
+        displayToast(error.message, 'error')
+      }
+    },
+    [addToken, refetch]
+  )
+
+  const onDelete = useCallback(async () => {
+    const { response } = await getResponse({
+      title: t('userSettings.apiTokens.deleteConfirmTitle'),
+      subText: t('userSettings.apiTokens.deleteConfirmMessage', {
+        ...selectedToken,
+        expires: new DateObject(selectedToken.expires).$.fromNow()
+      }),
+      responses: [
+        [t('common.yes'), true, true],
+        [t('common.no'), false, false]
+      ]
+    })
+    if (!response) return
+    await deleteToken({ variables: { name: selectedToken.name } })
+    displayToast(t('userSettings.apiTokens.tokenDeleted'), 'success')
+    onSelectionChanged(null)
+    refetch()
+  }, [selectedToken])
+
+  const onKeyCopied = useCallback(() => {
+    setNewToken(null)
+  }, [])
+
+  return {
+    items,
+    newToken,
+    selectedToken,
+    onSelectionChanged,
+    onTokenAdded,
+    onDelete,
+    onKeyCopied,
+    confirmationDialog
+  }
+}

--- a/client/parts/UserMenu/UserSettings/Tabs/index.ts
+++ b/client/parts/UserMenu/UserSettings/Tabs/index.ts
@@ -1,4 +1,5 @@
 export * from './General'
 export * from './Vacation'
 export * from './Timesheet'
+export * from './ApiTokens'
 export * from './types'

--- a/client/parts/UserMenu/UserSettings/UserSettings.tsx
+++ b/client/parts/UserMenu/UserSettings/UserSettings.tsx
@@ -1,10 +1,12 @@
 import { FormControl } from 'components'
 import { Tabs } from 'components/Tabs'
+import get from 'get-value'
 import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyledComponent } from 'types'
+import { useSubscriptionSettings } from 'AppContext'
 import { MenuItem } from '../MenuItem'
-import { General, Timesheet, Vacation } from './Tabs'
+import { General, Timesheet, Vacation, ApiTokensTab } from './Tabs'
 import { useUserSettings } from './useUserSettings'
 
 /**
@@ -13,6 +15,10 @@ import { useUserSettings } from './useUserSettings'
 export const UserSettings: StyledComponent = () => {
   const { t } = useTranslation()
   const { openPanel, formControlProps } = useUserSettings()
+  const settings = useSubscriptionSettings()
+  const patEnabled = get(settings, 'security.personalAccessTokensEnabled', {
+    default: true
+  })
 
   return useMemo(
     () => (
@@ -46,13 +52,25 @@ export const UserSettings: StyledComponent = () => {
                   iconName: 'WeatherSunnyLow'
                 },
                 formControlProps
-              ]
+              ],
+              ...(patEnabled
+                ? {
+                    apiTokens: [
+                      ApiTokensTab,
+                      {
+                        text: t('userSettings.apiTokens.tabTitle'),
+                        iconName: 'Key'
+                      },
+                      formControlProps
+                    ]
+                  }
+                : {})
             }}
           />
         </FormControl>
       </div>
     ),
-    [formControlProps.model]
+    [formControlProps.model, patEnabled]
   )
 }
 

--- a/client/parts/UserMenu/UserSettings/useUserSettings.ts
+++ b/client/parts/UserMenu/UserSettings/useUserSettings.ts
@@ -26,7 +26,8 @@ export function useUserSettings() {
     panel: {
       title: t('common.userSettingsPanelHeaderText'),
       open: panel.value,
-      onDismiss: () => panel.setFalse()
+      onDismiss: () => panel.setFalse(),
+      size: 'large'
     },
     submitProps: {
       text: t('common.save'),

--- a/client/parts/UserMenu/UserSettings/useUserSettings.ts
+++ b/client/parts/UserMenu/UserSettings/useUserSettings.ts
@@ -26,8 +26,7 @@ export function useUserSettings() {
     panel: {
       title: t('common.userSettingsPanelHeaderText'),
       open: panel.value,
-      onDismiss: () => panel.setFalse(),
-      size: 'large'
+      onDismiss: () => panel.setFalse()
     },
     submitProps: {
       text: t('common.save'),

--- a/docs/superpowers/plans/2026-04-13-did-skill-and-cli.md
+++ b/docs/superpowers/plans/2026-04-13-did-skill-and-cli.md
@@ -1,0 +1,983 @@
+# DID Skill & CLI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a standalone `did-cli` zsh tool wrapping DID's GraphQL API, plus a `/did` Claude Code skill in the DID repo that translates natural language into `did-cli` commands.
+
+**Architecture:** Two components - (1) `did-cli` is a zsh script mirroring the `get-token` CLI pattern (`.env` config, color-coded stderr logging, JSON stdout, symlink-based PATH install). It makes authenticated GraphQL requests to DID using a session cookie. (2) The `/did` skill interprets user intent, maps it to `did-cli` commands, runs them via Bash, and formats results.
+
+**Tech Stack:** zsh, curl, jq, GraphQL over HTTPS, Claude Code skill (markdown)
+
+---
+
+## File Structure
+
+### did-cli (`~/Code/CLI/did-cli/`)
+
+| File | Responsibility |
+|------|---------------|
+| `did-cli.zsh` | Main script: arg parsing, .env loading, GraphQL request execution, output formatting |
+| `.env.sample` | Template config with `DID_URL` and `DID_COOKIE` |
+| `queries/report.graphql` | Report query with full filter support |
+| `queries/timesheet.graphql` | Timesheet period query |
+| `queries/submit-period.graphql` | Submit period mutation |
+| `queries/status.graphql` | Combined status queries (currentUser + vacation) |
+| `queries/filter-options.graphql` | Report filter options query |
+| `add-to-path.sh` | Symlink installer to `/usr/local/bin/did-cli` |
+| `README.md` | Usage docs |
+
+### /did skill (`/Users/damsleth/Code/PZL/did/`)
+
+| File | Responsibility |
+|------|---------------|
+| `skills/did.md` | Claude Code skill definition |
+
+---
+
+### Task 1: Scaffold did-cli with .env and core utilities
+
+**Files:**
+- Create: `~/Code/CLI/did-cli/did-cli.zsh`
+- Create: `~/Code/CLI/did-cli/.env.sample`
+- Create: `~/Code/CLI/did-cli/.gitignore`
+
+- [ ] **Step 1: Create the directory**
+
+```bash
+mkdir -p ~/Code/CLI/did-cli/queries
+```
+
+- [ ] **Step 2: Create .env.sample**
+
+Write to `~/Code/CLI/did-cli/.env.sample`:
+
+```bash
+# did-cli configuration
+# [REQ] DID instance URL (without protocol)
+DID_URL=did.crayonconsulting.no
+
+# [REQ] Session cookie value from browser (cookie name: "didapp")
+DID_COOKIE=""
+
+# [OPT] Debug output (0=off, 1=on)
+debug=0
+```
+
+- [ ] **Step 3: Create .gitignore**
+
+Write to `~/Code/CLI/did-cli/.gitignore`:
+
+```
+.env
+```
+
+- [ ] **Step 4: Create did-cli.zsh with core structure**
+
+Write to `~/Code/CLI/did-cli/did-cli.zsh`:
+
+```zsh
+#!/bin/zsh
+
+# Resolve script directory (symlink-safe)
+SCRIPT_DIR="${0:A:h}"
+cd "$SCRIPT_DIR"
+
+# --- .env loading ---
+if [ ! -f .env ]; then
+  if [ -f .env.sample ]; then
+    if cp .env.sample .env 2>/dev/null; then
+      print -P "%F{yellow}Created .env from .env.sample. Set DID_COOKIE then re-run.%f" >&2
+      exit 2
+    fi
+  fi
+  print -P "%F{red}ERROR: .env not found. Copy .env.sample to .env and configure it.%f" >&2
+  exit 1
+fi
+source .env
+
+# --- Defaults ---
+: ${debug:=0}
+: ${DID_URL:=did.crayonconsulting.no}
+
+# --- Logging ---
+debug_log() { [[ "$debug" -eq 1 ]] && print -P "%F{green}DEBUG: $1%f" >&2 }
+error_log() { print -P "%F{red}ERROR: $1%f" >&2 }
+info_log()  { print -P "%F{cyan}$1%f" >&2 }
+
+# --- Dependency check ---
+check_dep() {
+  if ! command -v "$1" &>/dev/null; then
+    error_log "Required command '$1' not found."
+    exit 1
+  fi
+}
+check_dep curl
+check_dep jq
+
+# --- Cookie validation ---
+if [[ -z "$DID_COOKIE" ]]; then
+  error_log "DID_COOKIE not set. Get the 'didapp' cookie from your browser and add it to .env"
+  exit 1
+fi
+
+# --- GraphQL helper ---
+gql_request() {
+  local query_file="$1"
+  local variables="$2"
+  local query
+  query=$(<"$SCRIPT_DIR/queries/$query_file")
+
+  local body
+  body=$(jq -n --arg q "$query" --argjson v "${variables:-null}" '{ query: $q, variables: $v }')
+
+  debug_log "POST https://$DID_URL/graphql ($query_file)"
+
+  local response
+  response=$(curl -s -w "\n%{http_code}" \
+    -X POST "https://$DID_URL/graphql" \
+    -H "Content-Type: application/json" \
+    -H "Cookie: didapp=$DID_COOKIE" \
+    -d "$body")
+
+  local http_code
+  http_code=$(echo "$response" | tail -1)
+  local body_response
+  body_response=$(echo "$response" | sed '$d')
+
+  if [[ "$http_code" == "401" ]]; then
+    error_log "Session expired (401). Update your cookie: did-cli config --cookie <value>"
+    exit 1
+  fi
+
+  if [[ "$http_code" != "200" ]]; then
+    error_log "HTTP $http_code from DID API"
+    debug_log "$body_response"
+    exit 1
+  fi
+
+  local gql_errors
+  gql_errors=$(echo "$body_response" | jq -r '.errors // empty')
+  if [[ -n "$gql_errors" ]]; then
+    error_log "GraphQL error: $(echo "$body_response" | jq -r '.errors[0].message')"
+    exit 1
+  fi
+
+  echo "$body_response" | jq '.data'
+}
+
+# --- Date helpers ---
+current_year() { date +%Y }
+current_week() { date +%V | sed 's/^0//' }
+current_month() { date +%m | sed 's/^0//' }
+first_of_month() { date +%Y-%m-01 }
+today() { date +%Y-%m-%d }
+
+# Normalize date input: YYYY-MM -> YYYY-MM-01, YYYY-MM-DD -> as-is
+normalize_date() {
+  local d="$1"
+  if [[ "$d" =~ ^[0-9]{4}-[0-9]{2}$ ]]; then
+    echo "${d}-01"
+  else
+    echo "$d"
+  fi
+}
+
+# End-of-month for YYYY-MM input, otherwise return as-is
+normalize_end_date() {
+  local d="$1"
+  if [[ "$d" =~ ^[0-9]{4}-[0-9]{2}$ ]]; then
+    # Last day of that month
+    local year="${d:0:4}"
+    local month="${d:5:2}"
+    date -j -f "%Y-%m-%d" "${year}-${month}-01" +%Y-%m-%d 2>/dev/null | \
+      xargs -I{} date -j -v+1m -v-1d -f "%Y-%m-%d" {} +%Y-%m-%d
+  else
+    echo "$d"
+  fi
+}
+
+# --- Pretty formatting ---
+format_hours() {
+  local json="$1"
+  echo "$json" | jq -r '
+    def pad(n): tostring | if length < n then . + (" " * (n - length)) else . end;
+    (map(.duration) | add // 0) as $total |
+    "Customer            Project             Hours",
+    "---                 ---                 ---",
+    (.[] | "\(.customer.name | pad(20))\(.project.name | pad(20))\(.duration)"),
+    "",
+    "Total: \($total) hours"
+  '
+}
+
+# --- Subcommands ---
+
+cmd_status() {
+  info_log "Fetching status from $DID_URL..."
+  local data
+  data=$(gql_request "status.graphql" '{}')
+
+  local pretty="${1:-0}"
+  if [[ "$pretty" -eq 1 ]]; then
+    local balance
+    balance=$(echo "$data" | jq -r '.user.timebank.balance // "N/A"')
+    local vacation_total vacation_used vacation_remaining
+    vacation_total=$(echo "$data" | jq -r '.vacation.total // "N/A"')
+    vacation_used=$(echo "$data" | jq -r '.vacation.used // "N/A"')
+    vacation_remaining=$(echo "$data" | jq -r '.vacation.remaining // "N/A"')
+    local display_name
+    display_name=$(echo "$data" | jq -r '.user.displayName // "Unknown"')
+
+    print -P "%F{white}Status for %F{cyan}$display_name%f" >&2
+    print -P "%F{white}Time bank balance: %F{cyan}${balance}h%f" >&2
+    print -P "%F{white}Vacation: %F{cyan}${vacation_used}%f/%F{cyan}${vacation_total}%f days used, %F{cyan}${vacation_remaining}%f remaining" >&2
+  else
+    echo "$data"
+  fi
+}
+
+cmd_report() {
+  local customer="" project="" from="" to="" week="" year="" pretty=0
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --customer)  customer="$2"; shift 2 ;;
+      --project)   project="$2"; shift 2 ;;
+      --from)      from="$2"; shift 2 ;;
+      --to)        to="$2"; shift 2 ;;
+      --week)      week="$2"; shift 2 ;;
+      --year)      year="$2"; shift 2 ;;
+      --pretty)    pretty=1; shift ;;
+      *) error_log "Unknown flag: $1"; exit 1 ;;
+    esac
+  done
+
+  # Build variables JSON
+  local vars='{}'
+
+  if [[ -n "$customer" ]]; then
+    vars=$(echo "$vars" | jq --arg c "$customer" '. + { query: (.query // {} | . + { customerNames: [$c] }) }')
+  fi
+  if [[ -n "$project" ]]; then
+    vars=$(echo "$vars" | jq --arg p "$project" '. + { query: (.query // {} | . + { projectNames: [$p] }) }')
+  fi
+  if [[ -n "$from" ]]; then
+    local norm_from
+    norm_from=$(normalize_date "$from")
+    vars=$(echo "$vars" | jq --arg d "$norm_from" '. + { query: (.query // {} | . + { startDateTime: $d }) }')
+  fi
+  if [[ -n "$to" ]]; then
+    local norm_to
+    norm_to=$(normalize_end_date "$to")
+    vars=$(echo "$vars" | jq --arg d "$norm_to" '. + { query: (.query // {} | . + { endDateTime: $d }) }')
+  fi
+  if [[ -n "$week" ]]; then
+    vars=$(echo "$vars" | jq --argjson w "$week" '. + { query: (.query // {} | . + { week: $w }) }')
+  fi
+  if [[ -n "$year" ]]; then
+    vars=$(echo "$vars" | jq --argjson y "$year" '. + { query: (.query // {} | . + { year: $y }) }')
+  fi
+
+  # Default date range if nothing specified: current month
+  if [[ -z "$from" && -z "$to" && -z "$week" ]]; then
+    local default_from default_to
+    default_from=$(first_of_month)
+    default_to=$(today)
+    vars=$(echo "$vars" | jq --arg f "$default_from" --arg t "$default_to" \
+      '. + { query: (.query // {} | . + { startDateTime: $f, endDateTime: $t }) }')
+  fi
+
+  info_log "Querying hours from $DID_URL..."
+  local data
+  data=$(gql_request "report.graphql" "$vars")
+
+  if [[ "$pretty" -eq 1 ]]; then
+    echo "$data" | jq '.timeEntries' | format_hours /dev/stdin
+  else
+    echo "$data"
+  fi
+}
+
+cmd_submit() {
+  local week="" year="" confirm=0
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --period)
+        if [[ "$2" == "current" ]]; then
+          week=$(current_week)
+          year=$(current_year)
+        fi
+        shift 2 ;;
+      --week)    week="$2"; shift 2 ;;
+      --year)    year="$2"; shift 2 ;;
+      --confirm) confirm=1; shift ;;
+      *) error_log "Unknown flag: $1"; exit 1 ;;
+    esac
+  done
+
+  : ${week:=$(current_week)}
+  : ${year:=$(current_year)}
+
+  # Calculate start/end dates for the ISO week
+  # macOS date: get Monday of the given ISO week
+  local start_date end_date
+  start_date=$(python3 -c "from datetime import datetime, timedelta; d = datetime.strptime(f'${year}-W${week}-1', '%G-W%V-%u'); print(d.strftime('%Y-%m-%d'))")
+  end_date=$(python3 -c "from datetime import datetime, timedelta; d = datetime.strptime(f'${year}-W${week}-1', '%G-W%V-%u') + timedelta(days=6); print(d.strftime('%Y-%m-%d'))")
+
+  debug_log "Fetching timesheet for week $week/$year ($start_date to $end_date)"
+
+  # Fetch the timesheet period
+  local tz_offset
+  tz_offset=$(date +%z | sed 's/\([+-]\)\(.\)/\1/' | awk '{printf "%d", $1 * 60}')
+  # Simpler: just use minutes offset
+  tz_offset=$(python3 -c "import time; print(-time.timezone // 60 if time.daylight == 0 else -time.altzone // 60)")
+
+  local ts_vars
+  ts_vars=$(jq -n \
+    --arg sd "$start_date" \
+    --arg ed "$end_date" \
+    --argjson tz "$tz_offset" \
+    '{
+      query: { startDate: $sd, endDate: $ed },
+      options: { locale: "nb", dateFormat: "DD.MM.YYYY", tzOffset: $tz }
+    }')
+
+  local ts_data
+  ts_data=$(gql_request "timesheet.graphql" "$ts_vars")
+
+  # Find the matching period
+  local period
+  period=$(echo "$ts_data" | jq --argjson w "$week" '.periods[] | select(.week == $w)')
+
+  if [[ -z "$period" || "$period" == "null" ]]; then
+    error_log "No period found for week $week/$year"
+    exit 1
+  fi
+
+  local is_confirmed
+  is_confirmed=$(echo "$period" | jq -r '.isConfirmed')
+  if [[ "$is_confirmed" == "true" ]]; then
+    info_log "Week $week/$year is already submitted."
+    exit 0
+  fi
+
+  # Show summary
+  local event_count total_hours period_id period_start period_end
+  event_count=$(echo "$period" | jq '.events | length')
+  total_hours=$(echo "$period" | jq '[.events[].duration] | add // 0')
+  period_id=$(echo "$period" | jq -r '.id')
+  period_start=$(echo "$period" | jq -r '.startDate')
+  period_end=$(echo "$period" | jq -r '.endDate')
+
+  info_log "Week $week/$year: $event_count events, ${total_hours}h total"
+  info_log "Period: $period_start to $period_end"
+
+  if [[ "$confirm" -eq 0 ]]; then
+    print -P -n "%F{yellow}Submit this period? (y/N): %f" >&2
+    read -r answer
+    if [[ "$answer" != "y" && "$answer" != "Y" ]]; then
+      info_log "Aborted."
+      exit 0
+    fi
+  fi
+
+  # Build matched events for submission
+  local matched_events
+  matched_events=$(echo "$period" | jq '[.events[] | select(.project != null) | {
+    id: .id,
+    projectId: .project.tag,
+    manualMatch: false,
+    duration: .duration,
+    originalDuration: .originalDuration,
+    adjustedMinutes: .adjustedMinutes
+  }]')
+
+  local forecasted_hours
+  forecasted_hours=$(echo "$period" | jq '.forecastedHours // 0')
+
+  local submit_vars
+  submit_vars=$(jq -n \
+    --arg id "$period_id" \
+    --arg sd "$period_start" \
+    --arg ed "$period_end" \
+    --argjson events "$matched_events" \
+    --argjson fh "$forecasted_hours" \
+    --argjson tz "$tz_offset" \
+    '{
+      period: {
+        id: $id,
+        startDate: $sd,
+        endDate: $ed,
+        matchedEvents: $events,
+        forecastedHours: $fh
+      },
+      options: { locale: "nb", dateFormat: "DD.MM.YYYY", tzOffset: $tz }
+    }')
+
+  local result
+  result=$(gql_request "submit-period.graphql" "$submit_vars")
+
+  local success
+  success=$(echo "$result" | jq -r '.result.success')
+  if [[ "$success" == "true" ]]; then
+    info_log "Week $week/$year submitted successfully!"
+    echo "$result"
+  else
+    local err_msg
+    err_msg=$(echo "$result" | jq -r '.result.error.message // "Unknown error"')
+    error_log "Submission failed: $err_msg"
+    exit 1
+  fi
+}
+
+cmd_config() {
+  local url="" cookie=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --url)    url="$2"; shift 2 ;;
+      --cookie) cookie="$2"; shift 2 ;;
+      *) error_log "Unknown flag: $1"; exit 1 ;;
+    esac
+  done
+
+  if [[ -n "$url" ]]; then
+    if [[ -f .env ]]; then
+      sed -i '' "s|^DID_URL=.*|DID_URL=$url|" .env
+    fi
+    info_log "DID_URL set to $url"
+  fi
+
+  if [[ -n "$cookie" ]]; then
+    if [[ -f .env ]]; then
+      sed -i '' "s|^DID_COOKIE=.*|DID_COOKIE=$cookie|" .env
+    fi
+    info_log "DID_COOKIE updated"
+  fi
+
+  if [[ -z "$url" && -z "$cookie" ]]; then
+    info_log "Current config:"
+    info_log "  DID_URL=$DID_URL"
+    info_log "  DID_COOKIE=$(echo "$DID_COOKIE" | cut -c1-20)..."
+  fi
+}
+
+cmd_help() {
+  cat >&2 <<'HELP'
+did-cli - Command-line interface for DID timesheet
+
+Usage: did-cli <command> [options]
+
+Commands:
+  status              Show current period, time bank, and vacation
+  report              Query hours with filters
+  submit              Submit a timesheet period
+  config              View or update configuration
+  help                Show this help
+
+Report options:
+  --customer <name>   Filter by customer name
+  --project <name>    Filter by project name
+  --from <date>       Start date (YYYY-MM-DD or YYYY-MM)
+  --to <date>         End date (YYYY-MM-DD or YYYY-MM)
+  --week <number>     ISO week number
+  --year <number>     Year (default: current)
+  --pretty            Human-readable output (default: JSON)
+
+Submit options:
+  --period current    Submit the current open period
+  --week <number>     Specific week to submit
+  --year <number>     Year (default: current)
+  --confirm           Skip interactive prompt
+
+Config options:
+  --url <hostname>    Set DID instance URL
+  --cookie <value>    Set didapp session cookie
+
+Examples:
+  did-cli status --pretty
+  did-cli report --customer "Crayon" --from 2026-01 --to 2026-03 --pretty
+  did-cli report --week 15 --pretty
+  did-cli submit --period current
+  did-cli config --cookie "eyJ..."
+HELP
+}
+
+# --- Main dispatch ---
+case "${1:-help}" in
+  status)  shift; cmd_status "${@}" ;;
+  report)  shift; cmd_report "$@" ;;
+  submit)  shift; cmd_submit "$@" ;;
+  config)  shift; cmd_config "$@" ;;
+  help|--help|-h) cmd_help ;;
+  *) error_log "Unknown command: $1. Run 'did-cli help' for usage."; exit 1 ;;
+esac
+```
+
+- [ ] **Step 5: Make executable and commit**
+
+```bash
+chmod +x ~/Code/CLI/did-cli/did-cli.zsh
+cd ~/Code/CLI/did-cli
+git init
+git add .env.sample .gitignore did-cli.zsh
+git commit -m "feat: scaffold did-cli with core structure, .env, and all subcommands"
+```
+
+---
+
+### Task 2: Create GraphQL query files
+
+**Files:**
+- Create: `~/Code/CLI/did-cli/queries/report.graphql`
+- Create: `~/Code/CLI/did-cli/queries/timesheet.graphql`
+- Create: `~/Code/CLI/did-cli/queries/submit-period.graphql`
+- Create: `~/Code/CLI/did-cli/queries/status.graphql`
+- Create: `~/Code/CLI/did-cli/queries/filter-options.graphql`
+
+- [ ] **Step 1: Create report.graphql**
+
+Write to `~/Code/CLI/did-cli/queries/report.graphql`:
+
+```graphql
+query CustomReport($query: ReportsQuery, $sortAsc: Boolean) {
+  timeEntries: report(query: $query, sortAsc: $sortAsc, allowLarge: true) {
+    title
+    duration
+    startDateTime
+    endDateTime
+    week
+    month
+    year
+    customer {
+      key
+      name
+    }
+    project {
+      tag
+      name
+      parent {
+        tag
+        name
+      }
+    }
+    resource {
+      id
+    }
+    role {
+      name
+      hourlyRate
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Create timesheet.graphql**
+
+Write to `~/Code/CLI/did-cli/queries/timesheet.graphql`:
+
+```graphql
+query Timesheet($query: TimesheetQuery!, $options: TimesheetOptions!) {
+  periods: timesheet(query: $query, options: $options) {
+    id
+    week
+    month
+    startDate
+    endDate
+    events {
+      id
+      title
+      duration
+      originalDuration
+      adjustedMinutes
+      startDateTime
+      endDateTime
+      date
+      project {
+        tag
+        name
+      }
+      customer {
+        key
+        name
+      }
+    }
+    isConfirmed
+    isForecasted
+    isForecast
+    forecastedHours
+  }
+}
+```
+
+- [ ] **Step 3: Create submit-period.graphql**
+
+Write to `~/Code/CLI/did-cli/queries/submit-period.graphql`:
+
+```graphql
+mutation SubmitPeriod($period: TimesheetPeriodInput!, $options: TimesheetOptions!) {
+  result: submitPeriod(period: $period, options: $options) {
+    success
+    error {
+      message
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Create status.graphql**
+
+Write to `~/Code/CLI/did-cli/queries/status.graphql`:
+
+```graphql
+query Status {
+  user: currentUser {
+    id
+    displayName
+    mail
+    timebank {
+      balance
+      lastUpdated
+    }
+  }
+  vacation {
+    total
+    used
+    usedHours
+    remaining
+  }
+}
+```
+
+- [ ] **Step 5: Create filter-options.graphql**
+
+Write to `~/Code/CLI/did-cli/queries/filter-options.graphql`:
+
+```graphql
+query FilterOptions($query: ReportsQuery) {
+  filterOptions: reportFilterOptions(query: $query) {
+    projectNames
+    parentProjectNames
+    customerNames
+    partnerNames
+    employeeNames
+  }
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ~/Code/CLI/did-cli
+git add queries/
+git commit -m "feat: add GraphQL query files for report, timesheet, submit, status, and filters"
+```
+
+---
+
+### Task 3: Create add-to-path.sh and README
+
+**Files:**
+- Create: `~/Code/CLI/did-cli/add-to-path.sh`
+- Create: `~/Code/CLI/did-cli/README.md`
+
+- [ ] **Step 1: Create add-to-path.sh**
+
+Write to `~/Code/CLI/did-cli/add-to-path.sh`:
+
+```bash
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET="/usr/local/bin/did-cli"
+
+chmod +x "$SCRIPT_DIR/did-cli.zsh"
+
+if [ -L "$TARGET" ] || [ -e "$TARGET" ]; then
+  echo "'$TARGET' already exists. Overwrite? (y/N)"
+  read -r answer
+  [ "$answer" != "y" ] && echo "Aborted." && exit 1
+  rm "$TARGET"
+fi
+
+ln -s "$SCRIPT_DIR/did-cli.zsh" "$TARGET"
+echo "Linked $TARGET -> $SCRIPT_DIR/did-cli.zsh"
+echo "Run 'did-cli help' to get started."
+```
+
+- [ ] **Step 2: Create README.md**
+
+Write to `~/Code/CLI/did-cli/README.md`:
+
+```markdown
+# did-cli
+
+Command-line interface for [DID](https://did.crayonconsulting.no) timesheet operations.
+
+## Setup
+
+1. Clone this repo
+2. Run `./add-to-path.sh` to add `did-cli` to your PATH
+3. Get your `didapp` session cookie from the browser (DevTools > Application > Cookies)
+4. Configure: `did-cli config --cookie "your-cookie-value"`
+
+### Configuration
+
+```bash
+did-cli config --url did.crayonconsulting.no  # set instance (default)
+did-cli config --cookie "eyJ..."              # set session cookie
+did-cli config                                # show current config
+```
+
+## Usage
+
+### Check status
+
+```bash
+did-cli status --pretty
+```
+
+Shows time bank balance, vacation days, and user info.
+
+### Query hours
+
+```bash
+did-cli report --customer "Crayon" --from 2026-01 --to 2026-03 --pretty
+did-cli report --project "Alpha" --week 15 --pretty
+did-cli report --from 2026-03 --pretty
+```
+
+### Submit hours
+
+```bash
+did-cli submit --period current        # submit current week
+did-cli submit --week 15 --year 2026   # submit specific week
+did-cli submit --period current --confirm  # skip prompt
+```
+
+## Output
+
+Default output is JSON (for piping/scripting). Use `--pretty` for human-readable tables.
+
+## Requirements
+
+- zsh
+- curl
+- jq
+- python3 (for ISO week date calculation)
+```
+
+- [ ] **Step 3: Make add-to-path.sh executable and commit**
+
+```bash
+cd ~/Code/CLI/did-cli
+chmod +x add-to-path.sh
+git add add-to-path.sh README.md
+git commit -m "feat: add PATH installer and README"
+```
+
+---
+
+### Task 4: Test did-cli manually
+
+- [ ] **Step 1: Install to PATH**
+
+```bash
+cd ~/Code/CLI/did-cli
+./add-to-path.sh
+```
+
+- [ ] **Step 2: Configure with a real cookie**
+
+Get the `didapp` cookie value from the browser and run:
+
+```bash
+did-cli config --cookie "<paste cookie value>"
+```
+
+- [ ] **Step 3: Test status command**
+
+```bash
+did-cli status --pretty
+```
+
+Expected: displays user name, time bank balance, vacation info.
+
+- [ ] **Step 4: Test report command**
+
+```bash
+did-cli report --pretty
+did-cli report --week $(date +%V | sed 's/^0//') --pretty
+```
+
+Expected: shows time entries for current month / current week.
+
+- [ ] **Step 5: Test report with filters**
+
+```bash
+did-cli report --customer "Crayon" --from 2026-01 --to 2026-03 --pretty
+```
+
+Expected: filtered results or empty set if no matching entries.
+
+- [ ] **Step 6: Test submit (dry run)**
+
+```bash
+did-cli submit --period current
+```
+
+Expected: shows period summary, prompts for confirmation. Answer `N` to abort.
+
+- [ ] **Step 7: Fix any issues found during testing and commit**
+
+```bash
+cd ~/Code/CLI/did-cli
+git add -A
+git commit -m "fix: address issues found during manual testing"
+```
+
+---
+
+### Task 5: Create the /did Claude Code skill
+
+**Files:**
+- Create: `/Users/damsleth/Code/PZL/did/skills/did.md`
+
+- [ ] **Step 1: Create skills directory**
+
+```bash
+mkdir -p /Users/damsleth/Code/PZL/did/skills
+```
+
+- [ ] **Step 2: Write the skill file**
+
+Write to `/Users/damsleth/Code/PZL/did/skills/did.md`:
+
+````markdown
+---
+name: did
+description: Submit timesheet hours and query time data from DID via did-cli. Use when the user mentions submitting hours, checking hours, time bank, timesheet, or anything DID-related.
+---
+
+# DID Timesheet Assistant
+
+You help the user interact with their DID timesheet using the `did-cli` tool.
+
+## Prerequisites check
+
+Before doing anything, verify `did-cli` is available:
+
+```bash
+command -v did-cli
+```
+
+If not found, tell the user:
+> `did-cli` is not in your PATH. Set it up:
+> 1. Clone the did-cli repo
+> 2. Run `./add-to-path.sh`
+> 3. Run `did-cli config --cookie "<your didapp cookie>"`
+>
+> Get the cookie from your browser: DevTools > Application > Cookies > `didapp`
+
+If found, verify it's configured by running `did-cli config`. If `DID_COOKIE` is empty, walk the user through setting it.
+
+## Capabilities
+
+### 1. Submit hours
+
+When the user wants to submit/confirm their timesheet:
+
+1. Run `did-cli status` to check the current state
+2. Show the user a summary: time bank balance, current period status
+3. Run `did-cli submit --period current` (or `--week N --year Y` if they specify)
+4. The CLI will print a summary and ask for confirmation - let the user see it and decide
+5. **Never pass --confirm automatically.** Always let the user confirm interactively.
+
+### 2. Query hours
+
+When the user asks about their hours, translate to `did-cli report` with the right flags:
+
+| User says | Command |
+|-----------|---------|
+| "hours on Crayon in Q1" | `did-cli report --customer "Crayon" --from 2026-01 --to 2026-03` |
+| "hours last week" | `did-cli report --week <last week number>` |
+| "hours on Project Alpha" | `did-cli report --project "Alpha"` |
+| "hours in March" | `did-cli report --from 2026-03 --to 2026-03` |
+| "hours this year" | `did-cli report --from 2026-01 --to 2026-12` |
+| "break down by project" | Run report, then group the JSON output by project |
+
+Always use the JSON output (no `--pretty`) so you can parse and present the data flexibly. Format the results in a clear, readable way adapted to what the user asked for - totals, breakdowns by customer/project, weekly summaries, etc.
+
+For date math:
+- "last week" = current ISO week minus 1
+- "Q1" = --from YYYY-01 --to YYYY-03
+- "Q2" = --from YYYY-04 --to YYYY-06
+- "this month" = --from YYYY-MM --to YYYY-MM (current month)
+
+### 3. Check status / time bank
+
+When the user asks about time bank, vacation, or general status:
+
+```bash
+did-cli status
+```
+
+Parse the JSON and present: time bank balance, vacation days (used/remaining), user info.
+
+## Handling ambiguity
+
+If the user's query is ambiguous (e.g. a project name that could match multiple customers), run the report and check the results. If results span multiple customers/projects, ask the user to clarify.
+
+## Error handling
+
+- **401 / expired cookie**: Tell the user to refresh their cookie: `did-cli config --cookie "<new value>"`
+- **Empty results**: Report that no matching entries were found for the given filters
+- **CLI not found**: Walk through setup steps (see prerequisites)
+
+## Output formatting
+
+- For totals: single line with the number
+- For breakdowns: markdown table
+- For status: structured summary with labels
+- Match the granularity to what the user asked for - don't over-explain simple queries
+````
+
+- [ ] **Step 3: Commit the skill**
+
+```bash
+cd /Users/damsleth/Code/PZL/did
+git add skills/did.md
+git commit -m "feat: add /did Claude Code skill for timesheet operations"
+```
+
+---
+
+### Task 6: Test the /did skill end-to-end
+
+- [ ] **Step 1: Verify the skill loads**
+
+In the DID repo, check that Claude Code recognizes the skill:
+
+```bash
+# In the DID project directory, the skill should appear in the skill list
+```
+
+- [ ] **Step 2: Test "what's my time bank"**
+
+Invoke the skill and verify it runs `did-cli status` and formats the output.
+
+- [ ] **Step 3: Test "hours on [customer] this month"**
+
+Verify it translates to the correct `did-cli report` command and formats results.
+
+- [ ] **Step 4: Test "submit my hours"**
+
+Verify it shows the summary and lets the user confirm interactively.
+
+- [ ] **Step 5: Fix any issues and commit**
+
+```bash
+cd /Users/damsleth/Code/PZL/did
+git add skills/did.md
+git commit -m "fix: refine /did skill based on end-to-end testing"
+```

--- a/docs/superpowers/plans/2026-04-13-personal-access-tokens.md
+++ b/docs/superpowers/plans/2026-04-13-personal-access-tokens.md
@@ -1,0 +1,1144 @@
+# Personal Access Tokens - Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let any authenticated user create personal API tokens for scripting/automation, with user identity, scoped permissions, and admin oversight.
+
+**Architecture:** Extend the existing `ApiToken` model with `type` and `userId` fields. Add a new `PersonalAccessTokenResolver` for user-facing CRUD. Modify `handleTokenAuthentication()` to populate `userId` from PAT payloads. Add a tenant kill-switch setting. Add an "API tokens" tab to the UserSettings panel.
+
+**Tech Stack:** TypeGraphQL, MongoDB, jsonwebtoken, React, Fluent UI, i18next
+
+---
+
+### Task 1: Extend ApiToken Types with `type` and `userId`
+
+**Files:**
+- Modify: `server/graphql/resolvers/apiToken/types.ts`
+
+- [ ] **Step 1: Add `type` and `userId` fields to the `ApiToken` ObjectType**
+
+In `server/graphql/resolvers/apiToken/types.ts`, add two new fields to the `ApiToken` class after the `subscriptionId` field (line 55):
+
+```typescript
+/**
+ * The type of API token - 'subscription' (admin-created) or 'personal' (user-created).
+ */
+@Field(() => String, { nullable: true, defaultValue: 'subscription' })
+type?: 'subscription' | 'personal'
+
+/**
+ * The user ID that owns this token (personal tokens only).
+ */
+@Field(() => String, { nullable: true, defaultValue: null })
+userId?: string
+```
+
+- [ ] **Step 2: Verify the server compiles**
+
+Run: `npx tsc --noEmit --project server/tsconfig.json`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/graphql/resolvers/apiToken/types.ts
+git commit -m "feat(pat): add type and userId fields to ApiToken type"
+```
+
+---
+
+### Task 2: Add `tokenSource` to RequestContext
+
+**Files:**
+- Modify: `server/graphql/requestContext.ts`
+
+- [ ] **Step 1: Add `tokenSource` property to the `RequestContext` class**
+
+In `server/graphql/requestContext.ts`, add after the `permissions` property (line 74):
+
+```typescript
+/**
+ * Source of authentication for this request.
+ * 'pat' for personal access tokens, 'api' for subscription API tokens,
+ * null for interactive user sessions.
+ */
+public tokenSource?: 'pat' | 'api' | null
+```
+
+- [ ] **Step 2: Verify the server compiles**
+
+Run: `npx tsc --noEmit --project server/tsconfig.json`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/graphql/requestContext.ts
+git commit -m "feat(pat): add tokenSource property to RequestContext"
+```
+
+---
+
+### Task 3: Modify `handleTokenAuthentication` to Support PATs
+
+**Files:**
+- Modify: `server/graphql/requestContext.ts`
+
+- [ ] **Step 1: Update `handleTokenAuthentication` return type and logic**
+
+Replace the entire `handleTokenAuthentication` function (lines 228-252) with:
+
+```typescript
+const handleTokenAuthentication = async (
+  apiKey: string,
+  database: MongoDatabase
+) => {
+  const payload = verify(
+    apiKey,
+    environment('API_TOKEN_SECRET')
+  ) as any
+  const { expires, subscriptionId: _id, type, userId } = payload
+  const expired = new DateObject(expires).jsDate < new Date()
+  if (expired) throw new GraphQLError('The specified token is expired.')
+  const [token, subscription] = await Promise.all([
+    database.collection('api_tokens').findOne({
+      apiKey,
+      expires: {
+        $gte: new Date()
+      }
+    }),
+    database.collection('subscriptions').findOne({
+      _id
+    })
+  ])
+  if (!token || !subscription)
+    throw new GraphQLError('Failed to authenticate with the specified token.')
+  const tokenSource = type === 'personal' ? 'pat' : 'api'
+  return {
+    subscription,
+    permissions: token.permissions,
+    tokenSource,
+    userId: type === 'personal' ? userId : null
+  }
+}
+```
+
+- [ ] **Step 2: Update the API key path in `RequestContext.create` to use new return fields**
+
+In `RequestContext.create` (around lines 117-124), replace:
+
+```typescript
+      if (apiKey) {
+        // API key path remains snapshot-based as before
+        const { permissions, subscription } = await handleTokenAuthentication(
+          apiKey,
+          database
+        )
+        context.permissions = permissions
+        context.subscription = subscription
+```
+
+With:
+
+```typescript
+      if (apiKey) {
+        const { permissions, subscription, tokenSource, userId } =
+          await handleTokenAuthentication(apiKey, database)
+        context.permissions = permissions
+        context.subscription = subscription
+        context.tokenSource = tokenSource
+        if (userId) {
+          context.userId = userId
+        }
+```
+
+- [ ] **Step 3: Verify the server compiles**
+
+Run: `npx tsc --noEmit --project server/tsconfig.json`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/graphql/requestContext.ts
+git commit -m "feat(pat): populate userId and tokenSource from PAT tokens"
+```
+
+---
+
+### Task 4: Create the PersonalAccessToken Resolver
+
+**Files:**
+- Create: `server/graphql/resolvers/personalAccessToken/index.ts`
+- Modify: `server/graphql/resolvers/index.ts`
+
+- [ ] **Step 1: Create the resolver file**
+
+Create `server/graphql/resolvers/personalAccessToken/index.ts`:
+
+```typescript
+import 'reflect-metadata'
+import { Arg, Authorized, Ctx, Mutation, Query, Resolver } from 'type-graphql'
+import { Service } from 'typedi'
+import { GraphQLError } from 'graphql'
+import _ from 'underscore'
+import get from 'get-value'
+import { ApiTokenService } from '../../../services/mongo'
+import { IAuthOptions } from '../../authChecker'
+import { RequestContext } from '../../requestContext'
+import { BaseResult } from '../types'
+import { ApiToken, ApiTokenInput } from '../apiToken/types'
+
+const debug = require('debug')('graphql/personalAccessToken')
+
+/**
+ * Resolver for Personal Access Tokens.
+ *
+ * Unlike subscription API tokens, PATs are owned by individual users
+ * and carry user identity when used for authentication.
+ *
+ * @category GraphQL Resolver
+ */
+@Service()
+@Resolver(ApiToken)
+export class PersonalAccessTokenResolver {
+  constructor(private readonly _apiToken: ApiTokenService) {}
+
+  /**
+   * Get the current user's personal access tokens.
+   */
+  @Authorized<IAuthOptions>({ requiresUserContext: true })
+  @Query(() => [ApiToken], { description: 'Get personal access tokens for the current user' })
+  personalAccessTokens(@Ctx() context: RequestContext): Promise<ApiToken[]> {
+    return this._apiToken.getTokens({
+      subscriptionId: context.subscription.id,
+      userId: context.userId,
+      type: 'personal'
+    })
+  }
+
+  /**
+   * Create a personal access token.
+   * Validates that requested permissions are a subset of the user's current permissions.
+   * Checks that PATs are enabled for the subscription.
+   */
+  @Authorized<IAuthOptions>({ requiresUserContext: true })
+  @Mutation(() => String, { description: 'Create a personal access token' })
+  async addPersonalAccessToken(
+    @Arg('token') token: ApiTokenInput,
+    @Ctx() context: RequestContext
+  ): Promise<string> {
+    const patEnabled = get(
+      context.subscription,
+      'settings.security.personalAccessTokensEnabled',
+      { default: true }
+    )
+    if (!patEnabled) {
+      throw new GraphQLError(
+        'Personal access tokens are disabled for this organization',
+        { extensions: { code: 'FORBIDDEN' } }
+      )
+    }
+
+    const invalidPermissions = token.permissions.filter(
+      (p) => !_.contains(context.permissions, p)
+    )
+    if (invalidPermissions.length > 0) {
+      debug(
+        `User ${context.userId} attempted to create PAT with permissions they don't have: ${invalidPermissions.join(', ')}`
+      )
+      throw new GraphQLError(
+        'Cannot create token with permissions you do not have',
+        { extensions: { code: 'FORBIDDEN' } }
+      )
+    }
+
+    const existing = await this._apiToken.getTokens({
+      subscriptionId: context.subscription.id,
+      userId: context.userId,
+      type: 'personal',
+      name: token.name
+    })
+    if (existing.length > 0) {
+      throw new GraphQLError(
+        'A personal access token with this name already exists',
+        { extensions: { code: 'BAD_USER_INPUT' } }
+      )
+    }
+
+    const patToken = {
+      ...token,
+      type: 'personal' as const,
+      userId: context.userId
+    }
+    return this._apiToken.addToken(patToken, context.subscription.id)
+  }
+
+  /**
+   * Delete a personal access token owned by the current user.
+   */
+  @Authorized<IAuthOptions>({ requiresUserContext: true })
+  @Mutation(() => BaseResult, { description: 'Delete a personal access token' })
+  async deletePersonalAccessToken(
+    @Arg('name') name: string,
+    @Ctx() context: RequestContext
+  ): Promise<BaseResult> {
+    const [token] = await this._apiToken.getTokens({
+      subscriptionId: context.subscription.id,
+      userId: context.userId,
+      type: 'personal',
+      name
+    })
+    if (!token) {
+      throw new GraphQLError('Token not found', {
+        extensions: { code: 'NOT_FOUND' }
+      })
+    }
+    await this._apiToken.deleteToken(
+      name,
+      context.subscription.id,
+      context.userId
+    )
+    return { success: true, error: null }
+  }
+}
+```
+
+- [ ] **Step 2: Register the resolver**
+
+In `server/graphql/resolvers/index.ts`, add the import and include in the array:
+
+Add import after line 2:
+```typescript
+import { PersonalAccessTokenResolver } from './personalAccessToken'
+```
+
+Add `PersonalAccessTokenResolver` to the default export array (after `ApiTokenResolver`).
+
+Add a named export at the bottom:
+```typescript
+export { PersonalAccessTokenResolver } from './personalAccessToken'
+```
+
+- [ ] **Step 3: Verify the server compiles**
+
+Run: `npx tsc --noEmit --project server/tsconfig.json`
+Expected: May fail because `deleteToken` signature doesn't yet accept `userId`. That's Task 5.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/graphql/resolvers/personalAccessToken/index.ts server/graphql/resolvers/index.ts
+git commit -m "feat(pat): add PersonalAccessTokenResolver with CRUD operations"
+```
+
+---
+
+### Task 5: Update ApiTokenService for PAT Support
+
+**Files:**
+- Modify: `server/services/mongo/api_token.ts`
+
+- [ ] **Step 1: Update `addToken` to include `type` and `userId` in the JWT payload**
+
+The current `addToken` method (lines 52-71) already handles this correctly because it does `_.omit(token, 'created')` which will include any `type` and `userId` fields passed in. No change needed to `addToken`.
+
+- [ ] **Step 2: Update `deleteToken` to support user-scoped deletion**
+
+Replace the `deleteToken` method (lines 79-88) with:
+
+```typescript
+  /**
+   * Delete token
+   *
+   * @param name - Token name
+   * @param subscriptionId - Subscription id
+   * @param userId - Optional user id (for personal tokens, ensures ownership)
+   */
+  public async deleteToken(
+    name: string,
+    subscriptionId: string,
+    userId?: string
+  ): Promise<void> {
+    try {
+      const query: FilterQuery<ApiToken> = { name, subscriptionId }
+      if (userId) {
+        query.userId = userId
+      }
+      await this.collection.deleteOne(query)
+    } catch (error) {
+      throw error
+    }
+  }
+```
+
+- [ ] **Step 3: Verify the server compiles**
+
+Run: `npx tsc --noEmit --project server/tsconfig.json`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/services/mongo/api_token.ts
+git commit -m "feat(pat): update deleteToken to support user-scoped deletion"
+```
+
+---
+
+### Task 6: Add i18n Translation Keys
+
+**Files:**
+- Modify: `shared/config/security/permissions.ts` (if PAT-specific permissions labels needed)
+- Find and modify: the English translation file (likely `client/i18n/` or similar)
+
+- [ ] **Step 1: Find the translation files**
+
+Run: `find client -name '*.json' -path '*/i18n/*' -o -name '*.json' -path '*/locales/*' | head -20`
+
+Identify the English translation file and add these keys under appropriate namespaces:
+
+```json
+{
+  "common": {
+    "apiTokens": "API tokens"
+  },
+  "userSettings": {
+    "apiTokens": {
+      "tabTitle": "API tokens",
+      "emptyState": "You don't have any personal access tokens yet. Create one to access the API from scripts or integrations.",
+      "addNew": "Create token",
+      "delete": "Delete",
+      "tokenNameLabel": "Token name",
+      "tokenDescriptionDescription": "Describe what this token will be used for (minimum {{minLength}} characters)",
+      "tokenExpiryLabel": "Expiry",
+      "permissionsLabel": "Permissions",
+      "permissionsDescription": "Select which permissions this token should have. You can only grant permissions you currently have.",
+      "apiKeyGenerated": "Your new personal access token",
+      "tokenCreated": "Personal access token created",
+      "tokenDeleted": "Personal access token deleted",
+      "deleteConfirmTitle": "Delete personal access token",
+      "deleteConfirmMessage": "Are you sure you want to delete the token \"{{name}}\"? Any integrations using this token will stop working."
+    }
+  },
+  "admin": {
+    "subscriptionSettings": {
+      "personalAccessTokensEnabledLabel": "Allow personal access tokens",
+      "personalAccessTokensEnabledDescription": "When enabled, users can create personal API tokens for scripting and automation"
+    },
+    "apiTokens": {
+      "tokenType": "Type",
+      "tokenTypeSubscription": "Subscription",
+      "tokenTypePersonal": "Personal",
+      "tokenOwner": "Owner"
+    }
+  }
+}
+```
+
+Note: Find the actual translation file paths and JSON structure first. The keys above should be merged into the existing structure. Also add Norwegian (nb) translations.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add client/
+git commit -m "feat(pat): add i18n translation keys for personal access tokens"
+```
+
+---
+
+### Task 7: Add Tenant Kill-Switch Setting
+
+**Files:**
+- Modify: `client/pages/Admin/SubscriptionSettings/useSubscriptionConfig.ts`
+
+- [ ] **Step 1: Add the PAT toggle to the security section**
+
+In `client/pages/Admin/SubscriptionSettings/useSubscriptionConfig.ts`, find the security section's `fields` array (starts at line 192). Add a new field entry at the end of the security fields array (before the closing `]` of the security section, around line 262):
+
+```typescript
+        {
+          id: 'personalAccessTokensEnabled',
+          type: 'bool',
+          props: {
+            label: t('admin.subscriptionSettings.personalAccessTokensEnabledLabel'),
+            description: t('admin.subscriptionSettings.personalAccessTokensEnabledDescription'),
+            defaultValue: true
+          }
+        }
+```
+
+- [ ] **Step 2: Verify the client compiles**
+
+Run: `npx tsc --noEmit --project client/tsconfig.json` (or `npx webpack --mode development --stats errors-only`)
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/pages/Admin/SubscriptionSettings/useSubscriptionConfig.ts
+git commit -m "feat(pat): add personalAccessTokensEnabled tenant setting"
+```
+
+---
+
+### Task 8: Create GraphQL Operations for PAT Client
+
+**Files:**
+- Create: `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/personalAccessTokens.gql`
+- Create: `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/addPersonalAccessToken.gql`
+- Create: `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/deletePersonalAccessToken.gql`
+
+- [ ] **Step 1: Create the query file**
+
+Create `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/personalAccessTokens.gql`:
+
+```graphql
+query PersonalAccessTokens {
+  tokens: personalAccessTokens {
+    name
+    description
+    created
+    expires
+    secret: apiKey
+  }
+}
+```
+
+- [ ] **Step 2: Create the add mutation file**
+
+Create `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/addPersonalAccessToken.gql`:
+
+```graphql
+mutation AddPersonalAccessToken($token: ApiTokenInput!) {
+  apiKey: addPersonalAccessToken(token: $token)
+}
+```
+
+- [ ] **Step 3: Create the delete mutation file**
+
+Create `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/deletePersonalAccessToken.gql`:
+
+```graphql
+mutation DeletePersonalAccessToken($name: String!) {
+  result: deletePersonalAccessToken(name: $name) {
+    success
+    error {
+      message
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/parts/UserMenu/UserSettings/Tabs/ApiTokens/
+git commit -m "feat(pat): add GraphQL operations for personal access tokens"
+```
+
+---
+
+### Task 9: Create the PAT Management Hook
+
+**Files:**
+- Create: `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/usePersonalAccessTokens.tsx`
+
+- [ ] **Step 1: Create the hook**
+
+Create `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/usePersonalAccessTokens.tsx`:
+
+```typescript
+import { useMutation, useQuery } from '@apollo/client'
+import { useAppContext } from 'AppContext'
+import { useConfirmationDialog } from 'hooks'
+import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ApiToken } from '../../../../../../shared/graphql/types'
+import $addPersonalAccessToken from './addPersonalAccessToken.gql'
+import $deletePersonalAccessToken from './deletePersonalAccessToken.gql'
+import $personalAccessTokens from './personalAccessTokens.gql'
+
+export function usePersonalAccessTokens() {
+  const { t } = useTranslation()
+  const appContext = useAppContext()
+  const [newToken, setNewToken] = useState<ApiToken>(null)
+  const [selectedToken, setSelectedToken] = useState<ApiToken>(null)
+
+  const { data, refetch } = useQuery($personalAccessTokens, {
+    fetchPolicy: 'cache-and-network'
+  })
+  const items: ApiToken[] = data?.tokens ?? []
+
+  const [addToken] = useMutation($addPersonalAccessToken)
+  const [deleteToken] = useMutation($deletePersonalAccessToken)
+
+  const onTokenAdded = useCallback(
+    async (token: ApiToken) => {
+      try {
+        const { data } = await addToken({
+          variables: { token }
+        })
+        setNewToken({ ...token, apiKey: data.apiKey })
+        appContext.displayToast(
+          t('userSettings.apiTokens.tokenCreated'),
+          'success'
+        )
+        refetch()
+      } catch (error) {
+        appContext.displayToast(error.message, 'error')
+      }
+    },
+    [addToken, refetch]
+  )
+
+  const onDeleteConfirmed = useCallback(async () => {
+    if (!selectedToken) return
+    try {
+      await deleteToken({
+        variables: { name: selectedToken.name }
+      })
+      appContext.displayToast(
+        t('userSettings.apiTokens.tokenDeleted'),
+        'success'
+      )
+      setSelectedToken(null)
+      refetch()
+    } catch (error) {
+      appContext.displayToast(error.message, 'error')
+    }
+  }, [selectedToken, deleteToken, refetch])
+
+  const [confirmationDialog, onDelete] = useConfirmationDialog({
+    title: t('userSettings.apiTokens.deleteConfirmTitle'),
+    subText: t('userSettings.apiTokens.deleteConfirmMessage', {
+      name: selectedToken?.name
+    }),
+    onConfirm: onDeleteConfirmed
+  })
+
+  const onKeyCopied = useCallback(() => {
+    setNewToken(null)
+  }, [])
+
+  return {
+    items,
+    newToken,
+    selectedToken,
+    onSelectionChanged: setSelectedToken,
+    onTokenAdded,
+    onDelete,
+    onKeyCopied,
+    confirmationDialog
+  }
+}
+```
+
+Note: Verify the import paths match the project's alias configuration (the project uses webpack aliases like `AppContext`, `hooks`, etc.). Adjust the relative import for `ApiToken` type based on how the project resolves shared types. Check how `useConfirmationDialog` is imported in `useApiTokens.tsx` and match that pattern.
+
+- [ ] **Step 2: Verify the client compiles**
+
+Run: `npx tsc --noEmit` or check webpack build
+Expected: No errors (or expected errors if translation keys aren't wired yet)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/parts/UserMenu/UserSettings/Tabs/ApiTokens/usePersonalAccessTokens.tsx
+git commit -m "feat(pat): add usePersonalAccessTokens hook"
+```
+
+---
+
+### Task 10: Create the PAT Form Component
+
+**Files:**
+- Create: `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/PersonalAccessTokenForm.tsx`
+- Create: `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/usePersonalAccessTokenForm.ts`
+
+- [ ] **Step 1: Create the form hook**
+
+Create `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/usePersonalAccessTokenForm.ts`:
+
+```typescript
+import { useFormControlModel, useFormControls } from 'components/FormControl'
+import { ApiTokenInput } from '../../../../../../server/graphql/resolvers/apiToken/types'
+import { PersonalAccessTokenForm } from './PersonalAccessTokenForm'
+import { useExpiryOptions } from '../../../../../pages/Admin/ApiTokens/ApiTokenForm/useExpiryOptions'
+
+export function usePersonalAccessTokenForm(props: {
+  onTokenAdded: (token: any) => void
+  onDismiss: () => void
+}) {
+  const model = useFormControlModel<keyof ApiTokenInput>()
+  const register = useFormControls<keyof ApiTokenInput>(
+    model,
+    PersonalAccessTokenForm
+  )
+  const expiryOptions = useExpiryOptions()
+
+  const submitProps = {
+    text: 'Create',
+    onClick: async () => {
+      const token = model.$
+      await props.onTokenAdded(token)
+      model.reset()
+      props.onDismiss()
+    }
+  }
+
+  return { expiryOptions, submitProps, model, register }
+}
+```
+
+Note: Check how `useApiTokenFormSubmit` works in the admin form and mirror the pattern. The imports above use direct paths - adjust to match the project's alias pattern.
+
+- [ ] **Step 2: Create the form component**
+
+Create `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/PersonalAccessTokenForm.tsx`:
+
+```typescript
+import { DateObject } from 'DateUtils'
+import {
+  BaseControlOptions,
+  DropdownControl,
+  DropdownControlOptions,
+  FormControl,
+  InputControl
+} from 'components/FormControl'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyledComponent } from 'types'
+import { fuzzyMap } from 'utils'
+import { EditPermissions } from '../../../../pages/Admin/RolesPermissions'
+import { usePersonalAccessTokenForm } from './usePersonalAccessTokenForm'
+
+interface IPersonalAccessTokenFormProps {
+  open: boolean
+  onTokenAdded: (token: any) => void
+  onDismiss: () => void
+  tokens: any[]
+}
+
+export const PersonalAccessTokenForm: StyledComponent<
+  IPersonalAccessTokenFormProps
+> = (props) => {
+  const { t } = useTranslation()
+  const { expiryOptions, submitProps, model, register } =
+    usePersonalAccessTokenForm(props)
+  return (
+    <FormControl
+      id={PersonalAccessTokenForm.displayName}
+      model={model}
+      submitProps={submitProps}
+      panel={{
+        title: t('userSettings.apiTokens.addNew'),
+        open: props.open,
+        onDismiss: props.onDismiss
+      }}
+    >
+      <InputControl
+        {...register('name', { required: true })}
+        label={t('userSettings.apiTokens.tokenNameLabel')}
+      />
+      <InputControl
+        {...register('description', {
+          required: true,
+          validators: [{ minLength: 20 }]
+        })}
+        rows={8}
+        label={t('common.descriptionFieldLabel')}
+        description={t('userSettings.apiTokens.tokenDescriptionDescription', {
+          minLength: 20
+        })}
+      />
+      <DropdownControl
+        {...register<DropdownControlOptions>('expires', {
+          required: true,
+          preTransformValue: ({ optionValue }) =>
+            new DateObject().add(optionValue).jsDate
+        })}
+        label={t('userSettings.apiTokens.tokenExpiryLabel')}
+        values={fuzzyMap<any>(expiryOptions, (value, key) => ({
+          value: key,
+          text: value
+        }))}
+      />
+      <EditPermissions
+        {...register<BaseControlOptions>('permissions', {
+          validators: [
+            {
+              state: 'invalid',
+              func: (v: string[]) => !v || v.length === 0,
+              message: t('admin.apiTokens.editPermissionsDescription')
+            }
+          ]
+        })}
+        label={t('userSettings.apiTokens.permissionsLabel')}
+        description={t('userSettings.apiTokens.permissionsDescription')}
+        selectedPermissions={model.value('permissions')}
+        onChange={(selectedPermissions) =>
+          model.set('permissions', selectedPermissions)
+        }
+      />
+    </FormControl>
+  )
+}
+
+PersonalAccessTokenForm.displayName = 'PersonalAccessTokenForm'
+```
+
+Note: The `EditPermissions` component without `api={true}` will show all permissions. For PATs we want to show only permissions the user has. Check if `EditPermissions` supports filtering by user permissions or if you need to pass `scopeIds` to limit the options. The `usePermissions` hook accepts `scopeIds` as first arg - you may need to pass the user's current permissions to `EditPermissions` to filter the available options.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/parts/UserMenu/UserSettings/Tabs/ApiTokens/
+git commit -m "feat(pat): add PersonalAccessTokenForm component"
+```
+
+---
+
+### Task 11: Create the ApiTokens Tab Component
+
+**Files:**
+- Create: `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/ApiTokens.tsx`
+- Create: `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/index.ts`
+
+- [ ] **Step 1: Create the tab component**
+
+Create `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/ApiTokens.tsx`:
+
+```typescript
+import { SelectionMode } from 'components/List/types'
+import { List, ListMenuItem } from 'components'
+import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ApiKeyDisplay } from '../../../../../pages/Admin/ApiTokens/ApiKeyDisplay'
+import { PersonalAccessTokenForm } from './PersonalAccessTokenForm'
+import { usePersonalAccessTokens } from './usePersonalAccessTokens'
+
+export const ApiTokensTab: React.FC = () => {
+  const { t } = useTranslation()
+  const {
+    items,
+    newToken,
+    onTokenAdded,
+    onDelete,
+    onKeyCopied,
+    onSelectionChanged,
+    selectedToken,
+    confirmationDialog
+  } = usePersonalAccessTokens()
+  const [formOpen, setFormOpen] = useState(false)
+
+  const columns = [
+    {
+      fieldName: 'name',
+      key: 'name',
+      name: t('userSettings.apiTokens.tokenNameLabel'),
+      minWidth: 100,
+      maxWidth: 150
+    },
+    {
+      fieldName: 'description',
+      key: 'description',
+      name: t('common.descriptionFieldLabel'),
+      minWidth: 150,
+      maxWidth: 250,
+      isMultiline: true
+    },
+    {
+      fieldName: 'expires',
+      key: 'expires',
+      name: t('userSettings.apiTokens.tokenExpiryLabel'),
+      minWidth: 100,
+      maxWidth: 150,
+      onRender: (item: any) =>
+        item.expires ? new Date(item.expires).toLocaleDateString() : ''
+    }
+  ]
+
+  if (items.length === 0 && !newToken) {
+    return (
+      <div>
+        <p>{t('userSettings.apiTokens.emptyState')}</p>
+        <PersonalAccessTokenForm
+          open={formOpen}
+          onTokenAdded={onTokenAdded}
+          onDismiss={() => setFormOpen(false)}
+          tokens={items}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <ApiKeyDisplay
+        label={t('userSettings.apiTokens.apiKeyGenerated')}
+        apiKey={newToken?.apiKey}
+        onKeyCopied={() => onKeyCopied()}
+      />
+      <List
+        columns={columns}
+        items={items}
+        selectionProps={[SelectionMode.single, onSelectionChanged]}
+        menuItems={[
+          new ListMenuItem(t('userSettings.apiTokens.addNew'))
+            .withIcon('Add')
+            .setOnClick(() => setFormOpen(true)),
+          new ListMenuItem(t('userSettings.apiTokens.delete'))
+            .setOnClick(onDelete)
+            .withIcon('Delete')
+            .setGroup('actions')
+            .setDisabled(!selectedToken)
+        ]}
+      />
+      {formOpen && (
+        <PersonalAccessTokenForm
+          open={formOpen}
+          onTokenAdded={onTokenAdded}
+          onDismiss={() => setFormOpen(false)}
+          tokens={items}
+        />
+      )}
+      {confirmationDialog}
+    </div>
+  )
+}
+
+ApiTokensTab.displayName = 'ApiTokensTab'
+```
+
+Note: Check how the admin `ApiTokens` component uses `List`, `ListMenuItem`, `SelectionMode`, and columns. Mirror that exact pattern. The column definitions may need to use `IListColumn` type from `components/List`. Verify the `onRender` pattern matches the project's column API.
+
+- [ ] **Step 2: Create the barrel export**
+
+Create `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/index.ts`:
+
+```typescript
+export { ApiTokensTab } from './ApiTokens'
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/parts/UserMenu/UserSettings/Tabs/ApiTokens/
+git commit -m "feat(pat): add ApiTokensTab component for user settings"
+```
+
+---
+
+### Task 12: Wire the Tab into UserSettings
+
+**Files:**
+- Modify: `client/parts/UserMenu/UserSettings/UserSettings.tsx`
+- Modify: `client/parts/UserMenu/UserSettings/Tabs/index.ts`
+
+- [ ] **Step 1: Export the new tab from the Tabs barrel**
+
+In `client/parts/UserMenu/UserSettings/Tabs/index.ts`, add:
+
+```typescript
+export { ApiTokensTab } from './ApiTokens'
+```
+
+- [ ] **Step 2: Add the tab to UserSettings**
+
+In `client/parts/UserMenu/UserSettings/UserSettings.tsx`:
+
+Add import for the new tab and the subscription settings hook. Replace the imports on line 7:
+
+```typescript
+import { General, Timesheet, Vacation, ApiTokensTab } from './Tabs'
+```
+
+Add import for the subscription settings hook:
+
+```typescript
+import { useSubscriptionSettings } from 'AppContext'
+```
+
+Add import for `get`:
+
+```typescript
+import get from 'get-value'
+```
+
+Inside the `UserSettings` component, before the `return useMemo(...)`, add:
+
+```typescript
+  const settings = useSubscriptionSettings()
+  const patEnabled = get(settings, 'security.personalAccessTokensEnabled', { default: true })
+```
+
+In the `Tabs` `items` object, add the new tab after `vacation` (conditionally):
+
+```typescript
+              ...(patEnabled
+                ? {
+                    apiTokens: [
+                      ApiTokensTab,
+                      {
+                        text: t('userSettings.apiTokens.tabTitle'),
+                        iconName: 'Key'
+                      },
+                      formControlProps
+                    ]
+                  }
+                : {})
+```
+
+Update the `useMemo` dependencies (line 55) to include `patEnabled`:
+
+```typescript
+    [formControlProps.model, patEnabled]
+```
+
+- [ ] **Step 3: Verify the client compiles**
+
+Run: `npx tsc --noEmit` or check webpack
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/parts/UserMenu/UserSettings/ client/parts/UserMenu/UserSettings/Tabs/index.ts
+git commit -m "feat(pat): wire ApiTokens tab into UserSettings panel"
+```
+
+---
+
+### Task 13: Update Admin ApiTokens Page to Show Token Type
+
+**Files:**
+- Modify: `client/pages/Admin/ApiTokens/useColumns.tsx` (or wherever columns are defined)
+
+- [ ] **Step 1: Add a type column to the admin token list**
+
+In the admin token columns file, add a column that shows the token type. Find the columns array and add:
+
+```typescript
+{
+  fieldName: 'type',
+  key: 'type',
+  name: t('admin.apiTokens.tokenType'),
+  minWidth: 80,
+  maxWidth: 100,
+  onRender: (item: ApiToken) =>
+    item.type === 'personal'
+      ? t('admin.apiTokens.tokenTypePersonal')
+      : t('admin.apiTokens.tokenTypeSubscription')
+}
+```
+
+- [ ] **Step 2: Update the admin GraphQL query to include new fields**
+
+In `client/pages/Admin/ApiTokens/tokens.gql`, add `type` and `userId` to the query:
+
+```graphql
+query ApiTokens {
+  tokens: apiTokens {
+    name
+    description
+    created
+    expires
+    secret: apiKey
+    type
+    userId
+  }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/pages/Admin/ApiTokens/
+git commit -m "feat(pat): show token type in admin API tokens list"
+```
+
+---
+
+### Task 14: End-to-End Smoke Test
+
+**Files:** None (manual verification)
+
+- [ ] **Step 1: Start the dev server**
+
+Run: `npm run watch`
+Expected: Server and client start without errors
+
+- [ ] **Step 2: Test the PAT creation flow**
+
+1. Log in as a regular user
+2. Click avatar > Settings
+3. Verify the "API tokens" tab appears
+4. Click "API tokens" tab
+5. Verify empty state message shows
+6. Create a new PAT with name, description, permissions
+7. Verify the API key is displayed
+8. Copy the key
+
+- [ ] **Step 3: Test the PAT in a request**
+
+```bash
+curl -H "Authorization: Bearer <copied-token>" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ me { displayName } }"}' \
+  http://localhost:3000/graphql
+```
+
+Expected: Returns user data (because PAT carries userId)
+
+- [ ] **Step 4: Test admin visibility**
+
+1. Log in as admin
+2. Go to Admin > API Tokens
+3. Verify the PAT appears with type "Personal"
+
+- [ ] **Step 5: Test the kill switch**
+
+1. As admin, go to Admin > Subscription Settings > Security
+2. Disable "Allow personal access tokens"
+3. As regular user, verify the "API tokens" tab is hidden in settings
+4. Verify existing PATs still work for API calls
+
+- [ ] **Step 6: Test PAT deletion**
+
+1. As user, go to Settings > API tokens
+2. Select a token and delete it
+3. Verify the token no longer works for API calls
+
+- [ ] **Step 7: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix(pat): address issues found during smoke testing"
+```
+
+---
+
+## File Map Summary
+
+| Action | File |
+|--------|------|
+| Modify | `server/graphql/resolvers/apiToken/types.ts` |
+| Modify | `server/graphql/requestContext.ts` |
+| Create | `server/graphql/resolvers/personalAccessToken/index.ts` |
+| Modify | `server/graphql/resolvers/index.ts` |
+| Modify | `server/services/mongo/api_token.ts` |
+| Modify | `client/pages/Admin/SubscriptionSettings/useSubscriptionConfig.ts` |
+| Create | `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/personalAccessTokens.gql` |
+| Create | `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/addPersonalAccessToken.gql` |
+| Create | `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/deletePersonalAccessToken.gql` |
+| Create | `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/usePersonalAccessTokens.tsx` |
+| Create | `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/PersonalAccessTokenForm.tsx` |
+| Create | `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/usePersonalAccessTokenForm.ts` |
+| Create | `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/ApiTokens.tsx` |
+| Create | `client/parts/UserMenu/UserSettings/Tabs/ApiTokens/index.ts` |
+| Modify | `client/parts/UserMenu/UserSettings/UserSettings.tsx` |
+| Modify | `client/parts/UserMenu/UserSettings/Tabs/index.ts` |
+| Modify | `client/pages/Admin/ApiTokens/useColumns.tsx` |
+| Modify | `client/pages/Admin/ApiTokens/tokens.gql` |
+| Modify | i18n translation files (en, nb) |

--- a/docs/superpowers/specs/2026-04-13-did-skill-design.md
+++ b/docs/superpowers/specs/2026-04-13-did-skill-design.md
@@ -1,0 +1,222 @@
+# DID Skill & CLI Design Spec
+
+## Overview
+
+Two deliverables that give DID users a faster way to submit hours and query time data:
+
+1. **`did-cli`** - A standalone zsh CLI wrapping DID's GraphQL API
+2. **`/did` skill** - A Claude Code skill (shipped in the DID repo) that translates natural language into `did-cli` commands
+
+## Problem
+
+Submitting hours and checking time data requires opening the DID web app, navigating to the right page, and clicking through the UI. For power users already in the terminal, this is friction. A CLI + Claude Code skill lets them do it without leaving their workflow.
+
+## Architecture
+
+```
+User (natural language)
+  |
+  v
+/did skill (Claude Code)
+  |  interprets intent, builds command
+  v
+did-cli (zsh, in PATH)
+  |  GraphQL over HTTPS, cookie auth
+  v
+DID GraphQL API (did.crayonconsulting.no/graphql)
+```
+
+## Component 1: `did-cli`
+
+### Location
+
+`~/Code/CLI/did-cli/` - alongside `get-token`, same pattern.
+
+### Structure
+
+```
+did-cli/
+├── did-cli.zsh          # Main script
+├── .env.sample          # Template (url, cookie)
+├── .env                 # User config (gitignored)
+├── queries/             # GraphQL query files
+│   ├── report.graphql
+│   ├── submit-period.graphql
+│   ├── status.graphql
+│   └── timesheet.graphql
+├── add-to-path.sh       # PATH helper
+└── README.md
+```
+
+### Auth
+
+- DID API: `didapp` session cookie stored in `.env`
+- Configured via `did-cli config`
+
+### Commands
+
+#### `did-cli report`
+
+Query hours with flexible filters. Uses the `report` GraphQL query.
+
+```bash
+did-cli report --customer "Crayon" --from 2026-01 --to 2026-03
+did-cli report --project "Alpha" --week 15
+did-cli report --from 2026-03 --to 2026-03   # all hours in March
+```
+
+**Flags:**
+- `--customer <name>` - filter by customer name (maps to `customerNames`)
+- `--project <name>` - filter by project name (maps to `projectNames`)
+- `--from <date>` - start date. Accepts `YYYY-MM-DD` (specific day) or `YYYY-MM` (first of month). Defaults to start of current month if omitted.
+- `--to <date>` - end date. Same formats. Defaults to today if omitted.
+- `--week <number>` - ISO week number
+- `--year <number>` - year (defaults to current)
+- `--pretty` - human-readable table output (default: JSON)
+
+**GraphQL mapping:**
+- Query: `report`
+- Input: `ReportsQuery` with fields `customerNames`, `projectNames`, `startDateTime`, `endDateTime`, `week`, `year`
+
+#### `did-cli submit`
+
+Submit/confirm a timesheet period. Uses the `submitPeriod` mutation.
+
+```bash
+did-cli submit --period current
+did-cli submit --week 15 --year 2026
+```
+
+**Flow:**
+1. Fetches the period data via `timesheet` query
+2. Prints a summary (hours, matched events count)
+3. Requires `--confirm` flag or interactive y/n prompt
+4. Calls `submitPeriod` mutation
+
+**Flags:**
+- `--period current` - submit the current unconfirmed period
+- `--week <number>` - specific week
+- `--year <number>` - year (defaults to current)
+- `--confirm` - skip interactive prompt (for scripting)
+
+**GraphQL mapping:**
+- Read: `timesheet` query (to get period details)
+- Write: `submitPeriod` mutation (with `TimesheetPeriodInput`)
+
+#### `did-cli status`
+
+Show current period summary, time bank balance, and vacation days.
+
+```bash
+did-cli status
+did-cli status --pretty
+```
+
+**Returns:**
+- Current period: submitted/unsubmitted, total hours, event count
+- Time bank balance (from `currentUser.timebank.balance`)
+- Vacation summary (from `vacation` query: total, used, remaining)
+
+**GraphQL mapping:**
+- `timesheet` query (current period)
+- `currentUser` query (time bank)
+- `vacation` query (vacation days)
+
+### Configuration
+
+Via `.env` file (auto-created from `.env.sample` on first run):
+
+```env
+DID_URL=did.crayonconsulting.no
+DID_COOKIE=<didapp session cookie value>
+```
+
+Setup command:
+```bash
+did-cli config --url did.crayonconsulting.no --cookie "eyJ..."
+```
+
+### Output
+
+- Default: JSON to stdout (machine-readable for the skill)
+- `--pretty`: human-readable formatted output
+- Errors: JSON with `error` field, non-zero exit code
+
+### Error handling
+
+- 401/expired cookie: exit 1, message "Session expired. Update your cookie with: did-cli config --cookie <value>"
+- Network errors: exit 1, message with details
+- No matching data: exit 0, empty result set
+
+## Component 2: `/did` Claude Code Skill
+
+### Location
+
+Shipped in the DID repo. Exact path TBD (e.g. `skills/did.md` or similar, depending on project convention).
+
+### Trigger
+
+User intent related to timesheet operations: "submit my hours", "how many hours on X", "time bank balance", "week status", etc.
+
+### Behavior by intent
+
+| User says | Skill does |
+|-----------|-----------|
+| "submit my hours" | Runs `did-cli status` to show current period, then `did-cli submit --period current --confirm` after user confirmation |
+| "how many hours on Crayon in Q1" | Runs `did-cli report --customer Crayon --from 2026-01 --to 2026-03`, summarizes flexibly |
+| "what's my time bank" | Runs `did-cli status`, extracts and presents balance |
+| "hours last week" | Runs `did-cli report --week <N> --year <Y>`, summarizes |
+| "break down March by project" | Runs `did-cli report --from 2026-03 --to 2026-03`, groups response by project |
+
+### Safety
+
+- **Submit**: always shows summary and asks for user confirmation before executing
+- **Queries**: read-only, no confirmation gate
+
+### Prerequisites check
+
+On invocation, the skill verifies:
+1. `did-cli` is in PATH
+2. `did-cli` is configured (has a valid `.env`)
+
+If not, walks the user through setup.
+
+### Ambiguous queries
+
+When the user's request is ambiguous (e.g. "hours on Alpha" but multiple customers have a project called Alpha), the skill runs `did-cli report` with available filters and asks the user to clarify, potentially using `reportFilterOptions` query data.
+
+## Configuration
+
+### DID instance
+
+Base URL is configurable, defaults to `did.crayonconsulting.no`. Stored in `did-cli`'s `.env`.
+
+### Dependencies
+
+- `did-cli` in PATH
+- `curl` (HTTP requests)
+- `jq` (JSON parsing)
+- Valid `didapp` session cookie
+
+## Out of scope for v1
+
+- Calendar event editing (separate `/did-calendar` skill)
+- Personal access tokens for DID (replaces cookie auth, future)
+- Automatic cookie refresh
+- Remote/headless environment support
+- Graph API integration (belongs to calendar skill)
+
+## GraphQL API Reference
+
+### Queries used
+
+- **`report`** - time entries with filters (`customerNames`, `projectNames`, `startDateTime`, `endDateTime`, `week`, `year`, etc.)
+- **`reportFilterOptions`** - available filter values (customer names, project names, etc.)
+- **`timesheet`** - period data (`startDate`, `endDate`, locale/timezone options)
+- **`currentUser`** - user profile including `timebank.balance`
+- **`vacation`** - vacation summary (total, used, remaining)
+
+### Mutations used
+
+- **`submitPeriod`** - confirm a timesheet period (takes `TimesheetPeriodInput` + `TimesheetOptions`)
+- **`unsubmitPeriod`** - unconfirm a period (same args)

--- a/docs/superpowers/specs/2026-04-13-personal-access-tokens-design.md
+++ b/docs/superpowers/specs/2026-04-13-personal-access-tokens-design.md
@@ -1,0 +1,112 @@
+# Personal Access Tokens (PATs) - Design Spec
+
+## Overview
+
+Add self-service Personal Access Tokens so any authenticated user can create tokens for personal integrations (CLI tools, Power Automate flows, scripts) without requiring admin privileges. PATs carry user identity, making actions attributable but distinguishable from interactive sessions.
+
+## Approach
+
+Extend the existing subscription-level API token system rather than building a parallel one. The `ApiToken` model gains `type` and `userId` fields. JWT signing, validation, and storage reuse the existing pipeline.
+
+## Data Model
+
+Two new fields on the `ApiToken` document (MongoDB `api_tokens` collection):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `'subscription' \| 'personal'` | Token type. Existing tokens implicitly default to `'subscription'`. |
+| `userId` | `string \| null` | User ID for personal tokens. `null` for subscription tokens. |
+
+Both fields are included in the JWT payload so they're available during validation without a DB round-trip.
+
+**Backward compatibility:** Existing tokens continue to work. Missing `type` is treated as `'subscription'`, missing `userId` as `null`. No data migration required.
+
+**Token name uniqueness:** PAT names are unique per user. Subscription token names remain unique per subscription. A user and a subscription token can share the same name.
+
+## Authentication Flow
+
+Changes to `handleTokenAuthentication()` in `server/graphql/requestContext.ts`:
+
+1. JWT is verified and token looked up in DB (unchanged).
+2. If `token.type === 'personal'`: populate `context.userId` from the JWT payload.
+3. Add `context.tokenSource: 'pat' | 'api' | null` to the request context.
+
+Key behavioral difference: PATs **can** access resolvers marked with `requiresUserContext: true` because they carry a valid `userId`. Subscription tokens cannot (unchanged).
+
+The `tokenSource` field allows resolvers and downstream code to distinguish PAT-authenticated requests from interactive sessions for audit/logging purposes.
+
+## Server - Resolver
+
+A new `personalAccessToken` resolver, separate from the existing `apiToken` resolver:
+
+### Queries
+
+- `personalAccessTokens(): ApiToken[]` - List the current user's PATs. Requires user context. No special permission needed.
+
+### Mutations
+
+- `addPersonalAccessToken(token: ApiTokenInput): string` - Create a PAT. Requires user context. Server validates that requested permissions are a subset of the user's current role permissions. Sets `type: 'personal'` and `userId` from context. Returns the signed JWT.
+
+- `deletePersonalAccessToken(name: string): BaseResult` - Delete a PAT. Requires user context. Server enforces `userId` match (users can only delete their own).
+
+### Admin Extensions
+
+- The existing `apiTokens` query returns all tokens (subscription and personal) by default so admins can view PATs. An optional `type` filter parameter can narrow results.
+- The existing `deleteApiToken` mutation continues to work for admins to revoke any token, including PATs.
+
+## Server - Service
+
+Changes to `ApiTokenService` (`server/services/mongo/api_token.ts`):
+
+- `addToken` accepts the new fields (`type`, `userId`), includes them in the JWT payload.
+- `getTokens` supports filtering by `type` and/or `userId`.
+- JWT signing and storage logic unchanged.
+
+## Tenant Setting - PAT Kill Switch
+
+New boolean setting: `security.personalAccessTokensEnabled`
+
+- **Default:** `true`
+- **Location:** Security section of Admin > Subscription Settings
+- **Label:** "Allow users to create personal access tokens"
+
+### Enforcement
+
+- **Server:** `addPersonalAccessToken` mutation checks the setting before creating. Returns a GraphQL error if disabled.
+- **Client:** The "API tokens" tab in user settings is hidden when the setting is `false`.
+- **Existing PATs:** Continue to function when the setting is toggled off. Only new creation is blocked. Admins can revoke existing PATs individually.
+
+## Client UI
+
+### User Settings - New "API tokens" Tab
+
+Added to the UserSettings panel (`client/parts/UserMenu/UserSettings/`) alongside "general", "timesheet", and "vacation".
+
+**Components:**
+
+- **Token list:** Table with columns: name, description, created, expires. No permission column for end users.
+- **Create form:** Fields: name (required, unique per user), description (required, min 20 chars), expiry dropdown (same options as admin: 1mo, 3mo, 6mo, 1yr, 3yr, 5yr, 15yr), permission picker (shows only permissions the user currently has).
+- **Delete:** Per-token delete button with confirmation dialog.
+- **ApiKey display:** One-time display with copy-to-clipboard. Reuse or extract shared component from existing admin `ApiKeyDisplay`.
+- **Empty state:** Explanatory text about what PATs are and when to use them.
+- **Visibility:** Tab hidden when `security.personalAccessTokensEnabled` is `false`.
+
+### Admin ApiTokens Page - Minor Update
+
+Add a column or indicator showing token type (`subscription` vs `personal`) and the owning user's display name for PATs, so admins can identify and revoke user tokens.
+
+## Security
+
+- **Permission ceiling:** Server enforces PAT permissions are a strict subset of the user's current role permissions. The UI only shows available permissions, but the server validates regardless.
+- **No privilege escalation:** If a user's role is later downgraded, existing PATs retain their original permissions. Admins can revoke PATs to address this.
+- **Same signing secret:** PATs share `API_TOKEN_SECRET` with subscription tokens. The `type` field in the JWT distinguishes them during validation.
+- **One-time display:** JWT shown once on creation, never retrievable again.
+- **No token-to-token creation:** PATs require user context to create. A PAT cannot create another PAT.
+- **Rate limiting:** PATs go through the same Express rate limiter as all other requests.
+
+## Out of Scope
+
+- Automatic revocation when user permissions change (future enhancement)
+- Warning/logging when a PAT is used with permissions the user no longer holds (future enhancement)
+- Admin-configurable max expiry duration
+- Token refresh/rotation

--- a/server/graphql/authChecker.ts
+++ b/server/graphql/authChecker.ts
@@ -45,14 +45,11 @@ export const authChecker: AuthChecker<RequestContext, IAuthOptions> = (
     }
     return true
   }
-  if (authOptions.requiresUserContext) {
-    if (!context.userId) {
-      debug('User context required - no userId present')
-      throw new GraphQLError('User context required', {
-        extensions: { code: 'UNAUTHENTICATED' }
-      })
-    }
-    return true
+  if (authOptions.requiresUserContext && !context.userId) {
+    debug('User context required - no userId present')
+    throw new GraphQLError('User context required', {
+      extensions: { code: 'UNAUTHENTICATED' }
+    })
   }
   if (
     authOptions.scope &&

--- a/server/graphql/requestContext.ts
+++ b/server/graphql/requestContext.ts
@@ -74,6 +74,13 @@ export class RequestContext {
   public permissions?: string[]
 
   /**
+   * Source of authentication for this request.
+   * 'pat' for personal access tokens, 'api' for subscription API tokens,
+   * null for interactive user sessions.
+   */
+  public tokenSource?: 'pat' | 'api' | null
+
+  /**
    * Mongo client instance
    */
   public mcl?: MongoClient
@@ -115,13 +122,14 @@ export class RequestContext {
       context.subscription = get(request, 'user.subscription', { default: {} })
       const apiKey = get(request, 'api_key')
       if (apiKey) {
-        // API key path remains snapshot-based as before
-        const { permissions, subscription } = await handleTokenAuthentication(
-          apiKey,
-          database
-        )
+        const { permissions, subscription, tokenSource, userId } =
+          await handleTokenAuthentication(apiKey, database)
         context.permissions = permissions
         context.subscription = subscription
+        context.tokenSource = tokenSource
+        if (userId) {
+          context.userId = userId
+        }
       } else {
         // Populate basic user context
         context.user = get(request, 'user')
@@ -229,10 +237,11 @@ const handleTokenAuthentication = async (
   apiKey: string,
   database: MongoDatabase
 ) => {
-  const { expires, subscriptionId: _id } = verify(
+  const payload = verify(
     apiKey,
     environment('API_TOKEN_SECRET')
   ) as any
+  const { expires, subscriptionId: _id, type, userId } = payload
   const expired = new DateObject(expires).jsDate < new Date()
   if (expired) throw new GraphQLError('The specified token is expired.')
   const [token, subscription] = await Promise.all([
@@ -248,5 +257,11 @@ const handleTokenAuthentication = async (
   ])
   if (!token || !subscription)
     throw new GraphQLError('Failed to authenticate with the specified token.')
-  return { subscription, permissions: token.permissions }
+  const tokenSource: 'pat' | 'api' = type === 'personal' ? 'pat' : 'api'
+  return {
+    subscription,
+    permissions: token.permissions,
+    tokenSource,
+    userId: type === 'personal' ? userId : null
+  }
 }

--- a/server/graphql/resolvers/apiToken/index.ts
+++ b/server/graphql/resolvers/apiToken/index.ts
@@ -2,7 +2,10 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import 'reflect-metadata'
 import { Arg, Authorized, Ctx, Mutation, Query, Resolver } from 'type-graphql'
+import { GraphQLError } from 'graphql'
 import { Service } from 'typedi'
+import _ from 'underscore'
+import { PermissionScope } from '../../../../shared/config/security'
 import { ApiTokenService } from '../../../services/mongo'
 import { IAuthOptions } from '../../authChecker'
 import { RequestContext } from '../../requestContext'
@@ -30,16 +33,41 @@ export class ApiTokenResolver {
   constructor(private readonly _apiToken: ApiTokenService) {}
 
   /**
+   * Token management must be performed from an interactive user session.
+   */
+  private assertInteractiveSession(context: RequestContext): void {
+    if (context.tokenSource) {
+      throw new GraphQLError(
+        'Interactive session required to manage API tokens.',
+        { extensions: { code: 'FORBIDDEN' } }
+      )
+    }
+  }
+
+  /**
    * Get API tokens
    *
    * @param ctx - GraphQL context
    */
-  @Authorized<IAuthOptions>({ requiresUserContext: true })
+  @Authorized<IAuthOptions>({
+    requiresUserContext: true,
+    scope: PermissionScope.LIST_API_TOKENS
+  })
   @Query(() => [ApiToken], { description: 'Get API tokens' })
-  apiTokens(@Ctx() context: RequestContext): Promise<ApiToken[]> {
-    return this._apiToken.getTokens({
+  async apiTokens(@Ctx() context: RequestContext): Promise<ApiToken[]> {
+    this.assertInteractiveSession(context)
+    const canManageTokens = _.contains(
+      context.permissions,
+      PermissionScope.MANAGE_API_TOKENS
+    )
+    const tokens = await this._apiToken.getTokens({
       subscriptionId: context.subscription.id
     })
+    return tokens.map((token) => ({
+      ...token,
+      apiKey:
+        canManageTokens && token.type !== 'personal' ? token.apiKey : undefined
+    }))
   }
 
   /**
@@ -48,12 +76,16 @@ export class ApiTokenResolver {
    * @param token - Token
    * @param ctx - GraphQL context
    */
-  @Authorized<IAuthOptions>({ requiresUserContext: true })
+  @Authorized<IAuthOptions>({
+    requiresUserContext: true,
+    scope: PermissionScope.MANAGE_API_TOKENS
+  })
   @Mutation(() => String, { description: 'Add API token' })
   addApiToken(
     @Arg('token') token: ApiTokenInput,
     @Ctx() context: RequestContext
   ): Promise<string> {
+    this.assertInteractiveSession(context)
     return this._apiToken.addToken(token, context.subscription.id)
   }
 
@@ -63,13 +95,23 @@ export class ApiTokenResolver {
    * @param name - Name
    * @param ctx - GraphQL context
    */
-  @Authorized<IAuthOptions>({ requiresUserContext: true })
+  @Authorized<IAuthOptions>({
+    requiresUserContext: true,
+    scope: PermissionScope.MANAGE_API_TOKENS
+  })
   @Mutation(() => BaseResult, { description: 'Delete API tokens' })
   async deleteApiToken(
     @Arg('name') name: string,
-    @Ctx() context: RequestContext
+    @Ctx() context: RequestContext,
+    @Arg('type', () => String, { nullable: true })
+    type?: 'subscription' | 'personal',
+    @Arg('userId', () => String, { nullable: true }) userId?: string
   ): Promise<BaseResult> {
-    await this._apiToken.deleteToken(name, context.subscription.id)
+    this.assertInteractiveSession(context)
+    await this._apiToken.deleteToken(name, context.subscription.id, {
+      type,
+      userId
+    })
     return { success: true, error: null }
   }
 }

--- a/server/graphql/resolvers/apiToken/types.ts
+++ b/server/graphql/resolvers/apiToken/types.ts
@@ -53,6 +53,18 @@ export class ApiToken {
    * The subscription ID associated with the API token.
    */
   subscriptionId?: string
+
+  /**
+   * The type of API token - 'subscription' (admin-created) or 'personal' (user-created).
+   */
+  @Field(() => String, { nullable: true, defaultValue: 'subscription' })
+  type?: 'subscription' | 'personal'
+
+  /**
+   * The user ID that owns this token (personal tokens only).
+   */
+  @Field(() => String, { nullable: true, defaultValue: null })
+  userId?: string
 }
 
 /**

--- a/server/graphql/resolvers/index.ts
+++ b/server/graphql/resolvers/index.ts
@@ -1,5 +1,6 @@
 import { NonEmptyArray } from 'type-graphql'
 import { ApiTokenResolver } from './apiToken'
+import { PersonalAccessTokenResolver } from './personalAccessToken'
 import { CustomerResolver } from './customer'
 import { LabelResolver } from './label'
 import { NotificationResolver } from './notification'
@@ -14,6 +15,7 @@ import { UserResolver } from './user'
 
 export default [
   ApiTokenResolver,
+  PersonalAccessTokenResolver,
   CustomerResolver,
   LabelResolver,
   NotificationResolver,
@@ -27,6 +29,7 @@ export default [
   ReportLinkResolver
 ] as NonEmptyArray<any>
 export { ApiTokenResolver } from './apiToken'
+export { PersonalAccessTokenResolver } from './personalAccessToken'
 export { CustomerResolver } from './customer/CustomerResolver'
 export { LabelResolver } from './label'
 export { NotificationResolver } from './notification'

--- a/server/graphql/resolvers/personalAccessToken/index.ts
+++ b/server/graphql/resolvers/personalAccessToken/index.ts
@@ -1,0 +1,129 @@
+import 'reflect-metadata'
+import { Arg, Authorized, Ctx, Mutation, Query, Resolver } from 'type-graphql'
+import { Service } from 'typedi'
+import { GraphQLError } from 'graphql'
+import _ from 'underscore'
+import get from 'get-value'
+import { ApiTokenService } from '../../../services/mongo'
+import { IAuthOptions } from '../../authChecker'
+import { RequestContext } from '../../requestContext'
+import { BaseResult } from '../types'
+import { ApiToken, ApiTokenInput } from '../apiToken/types'
+
+const debug = require('debug')('graphql/personalAccessToken')
+
+/**
+ * Resolver for Personal Access Tokens.
+ *
+ * Unlike subscription API tokens, PATs are owned by individual users
+ * and carry user identity when used for authentication.
+ *
+ * @category GraphQL Resolver
+ */
+@Service()
+@Resolver(ApiToken)
+export class PersonalAccessTokenResolver {
+  constructor(private readonly _apiToken: ApiTokenService) {}
+
+  /**
+   * Get the current user's personal access tokens.
+   */
+  @Authorized<IAuthOptions>({ requiresUserContext: true })
+  @Query(() => [ApiToken], {
+    description: 'Get personal access tokens for the current user'
+  })
+  personalAccessTokens(@Ctx() context: RequestContext): Promise<ApiToken[]> {
+    return this._apiToken.getTokens({
+      subscriptionId: context.subscription.id,
+      userId: context.userId,
+      type: 'personal'
+    })
+  }
+
+  /**
+   * Create a personal access token.
+   * Validates that requested permissions are a subset of the user's current permissions.
+   * Checks that PATs are enabled for the subscription.
+   */
+  @Authorized<IAuthOptions>({ requiresUserContext: true })
+  @Mutation(() => String, { description: 'Create a personal access token' })
+  async addPersonalAccessToken(
+    @Arg('token') token: ApiTokenInput,
+    @Ctx() context: RequestContext
+  ): Promise<string> {
+    const patEnabled = get(
+      context.subscription,
+      'settings.security.personalAccessTokensEnabled',
+      { default: true }
+    )
+    if (!patEnabled) {
+      throw new GraphQLError(
+        'Personal access tokens are disabled for this organization',
+        { extensions: { code: 'FORBIDDEN' } }
+      )
+    }
+
+    const invalidPermissions = token.permissions.filter(
+      (p) => !_.contains(context.permissions, p)
+    )
+    if (invalidPermissions.length > 0) {
+      debug(
+        `User ${context.userId} attempted to create PAT with permissions they don't have: ${invalidPermissions.join(', ')}`
+      )
+      throw new GraphQLError(
+        'Cannot create token with permissions you do not have',
+        { extensions: { code: 'FORBIDDEN' } }
+      )
+    }
+
+    const existing = await this._apiToken.getTokens({
+      subscriptionId: context.subscription.id,
+      userId: context.userId,
+      type: 'personal',
+      name: token.name
+    })
+    if (existing.length > 0) {
+      throw new GraphQLError(
+        'A personal access token with this name already exists',
+        { extensions: { code: 'BAD_USER_INPUT' } }
+      )
+    }
+
+    const patToken = {
+      ...token,
+      type: 'personal' as const,
+      userId: context.userId
+    }
+    return this._apiToken.addToken(patToken, context.subscription.id)
+  }
+
+  /**
+   * Delete a personal access token owned by the current user.
+   */
+  @Authorized<IAuthOptions>({ requiresUserContext: true })
+  @Mutation(() => BaseResult, {
+    description: 'Delete a personal access token'
+  })
+  async deletePersonalAccessToken(
+    @Arg('name') name: string,
+    @Ctx() context: RequestContext
+  ): Promise<BaseResult> {
+    const [token] = await this._apiToken.getTokens({
+      subscriptionId: context.subscription.id,
+      userId: context.userId,
+      type: 'personal',
+      name
+    })
+    if (!token) {
+      throw new GraphQLError('Token not found', {
+        extensions: { code: 'NOT_FOUND' }
+      })
+    }
+    await this._apiToken.deleteToken(
+      name,
+      context.subscription.id,
+      context.userId
+    )
+    return { success: true, error: null }
+  }
+}

--- a/server/graphql/resolvers/personalAccessToken/index.ts
+++ b/server/graphql/resolvers/personalAccessToken/index.ts
@@ -26,18 +26,37 @@ export class PersonalAccessTokenResolver {
   constructor(private readonly _apiToken: ApiTokenService) {}
 
   /**
+   * PAT management must be performed from an interactive user session.
+   */
+  private assertInteractiveSession(context: RequestContext): void {
+    if (context.tokenSource) {
+      throw new GraphQLError(
+        'Interactive session required to manage personal access tokens.',
+        { extensions: { code: 'FORBIDDEN' } }
+      )
+    }
+  }
+
+  /**
    * Get the current user's personal access tokens.
    */
   @Authorized<IAuthOptions>({ requiresUserContext: true })
   @Query(() => [ApiToken], {
     description: 'Get personal access tokens for the current user'
   })
-  personalAccessTokens(@Ctx() context: RequestContext): Promise<ApiToken[]> {
-    return this._apiToken.getTokens({
+  async personalAccessTokens(
+    @Ctx() context: RequestContext
+  ): Promise<ApiToken[]> {
+    this.assertInteractiveSession(context)
+    const tokens = await this._apiToken.getTokens({
       subscriptionId: context.subscription.id,
       userId: context.userId,
       type: 'personal'
     })
+    return tokens.map((token) => ({
+      ...token,
+      apiKey: undefined
+    }))
   }
 
   /**
@@ -51,6 +70,7 @@ export class PersonalAccessTokenResolver {
     @Arg('token') token: ApiTokenInput,
     @Ctx() context: RequestContext
   ): Promise<string> {
+    this.assertInteractiveSession(context)
     const patEnabled = get(
       context.subscription,
       'settings.security.personalAccessTokensEnabled',
@@ -108,6 +128,7 @@ export class PersonalAccessTokenResolver {
     @Arg('name') name: string,
     @Ctx() context: RequestContext
   ): Promise<BaseResult> {
+    this.assertInteractiveSession(context)
     const [token] = await this._apiToken.getTokens({
       subscriptionId: context.subscription.id,
       userId: context.userId,
@@ -122,7 +143,10 @@ export class PersonalAccessTokenResolver {
     await this._apiToken.deleteToken(
       name,
       context.subscription.id,
-      context.userId
+      {
+        type: 'personal',
+        userId: context.userId
+      }
     )
     return { success: true, error: null }
   }

--- a/server/services/mongo/api_token.ts
+++ b/server/services/mongo/api_token.ts
@@ -16,6 +16,33 @@ import { MongoDocumentService } from './document'
 @Service({ global: false })
 export class ApiTokenService extends MongoDocumentService<ApiToken> {
   /**
+   * Builds a token query for lookup/delete operations.
+   *
+   * `type` is included to avoid ambiguous deletes between subscription
+   * tokens and personal tokens that happen to share the same name.
+   */
+  private buildTokenQuery(
+    name: string,
+    subscriptionId: string,
+    options?: {
+      type?: 'subscription' | 'personal'
+      userId?: string
+    }
+  ): FilterQuery<ApiToken> {
+    const query: FilterQuery<ApiToken> = { name, subscriptionId }
+    if (options?.type) {
+      query.type =
+        options.type === 'subscription'
+          ? { $in: ['subscription', null] }
+          : options.type
+    }
+    if (options?.userId) {
+      query.userId = options.userId
+    }
+    return query
+  }
+
+  /**
    * Constructor for `ApiTokenService`
    *
    * @param context - Injected context through `typedi`
@@ -80,13 +107,13 @@ export class ApiTokenService extends MongoDocumentService<ApiToken> {
   public async deleteToken(
     name: string,
     subscriptionId: string,
-    userId?: string
+    options?: {
+      type?: 'subscription' | 'personal'
+      userId?: string
+    }
   ): Promise<void> {
     try {
-      const query: FilterQuery<ApiToken> = { name, subscriptionId }
-      if (userId) {
-        query.userId = userId
-      }
+      const query = this.buildTokenQuery(name, subscriptionId, options)
       await this.collection.deleteOne(query)
     } catch (error) {
       throw error

--- a/server/services/mongo/api_token.ts
+++ b/server/services/mongo/api_token.ts
@@ -75,13 +75,19 @@ export class ApiTokenService extends MongoDocumentService<ApiToken> {
    *
    * @param name - Token name
    * @param subscriptionId - Subscription id
+   * @param userId - Optional user id (for personal tokens, ensures ownership)
    */
   public async deleteToken(
     name: string,
-    subscriptionId: string
+    subscriptionId: string,
+    userId?: string
   ): Promise<void> {
     try {
-      await this.collection.deleteOne({ name, subscriptionId })
+      const query: FilterQuery<ApiToken> = { name, subscriptionId }
+      if (userId) {
+        query.userId = userId
+      }
+      await this.collection.deleteOne(query)
     } catch (error) {
       throw error
     }

--- a/server/services/mongo/document/MongoDocumentService.ts
+++ b/server/services/mongo/document/MongoDocumentService.ts
@@ -21,6 +21,16 @@ export class MongoDocumentService<T> {
   private _extensions: Extensions = new Map()
 
   /**
+   * Resolves the current actor ID for audit fields.
+   *
+   * PAT-authenticated requests populate `context.userId` without
+   * populating the interactive `context.user` object.
+   */
+  protected get actorUserId(): string | undefined {
+    return this.context.user?.id || this.context.userId
+  }
+
+  /**
    * Constructer for `MongoDocumentService`
    *
    * Specify `cachePrefix` to use an underlying `CacheService`
@@ -254,8 +264,8 @@ export class MongoDocumentService<T> {
       ...document_,
       createdAt: new Date(),
       updatedAt: new Date(),
-      createdBy: this.context.user?.id,
-      updatedBy: this.context.user?.id
+      createdBy: this.actorUserId,
+      updatedBy: this.actorUserId
     }))
     return this.collection.insertMany(documents)
   }
@@ -277,8 +287,8 @@ export class MongoDocumentService<T> {
         ...document,
         createdAt: new Date(),
         updatedAt: new Date(),
-        createdBy: this.context.user?.id,
-        updatedBy: this.context.user?.id
+        createdBy: this.actorUserId,
+        updatedBy: this.actorUserId
       } as OptionalId<T>
     ) as Promise<InsertOneWriteOpResult<WithId<T>>>
   }
@@ -297,7 +307,7 @@ export class MongoDocumentService<T> {
       $set: {
         ...document,
         updatedAt: new Date(),
-        updatedBy: this.context.user?.id
+        updatedBy: this.actorUserId
       }
     })
   }

--- a/skills/did.md
+++ b/skills/did.md
@@ -1,0 +1,88 @@
+---
+name: did
+description: Submit timesheet hours and query time data from DID via did-cli. Use when the user mentions submitting hours, checking hours, time bank, timesheet, or anything DID-related.
+---
+
+# DID Timesheet Assistant
+
+You help the user interact with their DID timesheet using the `did-cli` tool.
+
+## Prerequisites check
+
+Before doing anything, verify `did-cli` is available:
+
+```bash
+command -v did-cli
+```
+
+If not found, tell the user:
+> `did-cli` is not in your PATH. Set it up:
+> 1. Clone the did-cli repo
+> 2. Run `./add-to-path.sh`
+> 3. Run `did-cli config --cookie "<your didapp cookie>"`
+>
+> Get the cookie from your browser: DevTools > Application > Cookies > `didapp`
+
+If found, verify it's configured by running `did-cli config`. If `DID_COOKIE` is empty, walk the user through setting it.
+
+## Capabilities
+
+### 1. Submit hours
+
+When the user wants to submit/confirm their timesheet:
+
+1. Run `did-cli status` to check the current state
+2. Show the user a summary: time bank balance, current period status
+3. Run `did-cli submit --period current` (or `--week N --year Y` if they specify)
+4. The CLI will print a summary and ask for confirmation - let the user see it and decide
+5. **Never pass --confirm automatically.** Always let the user confirm interactively.
+
+### 2. Query hours
+
+When the user asks about their hours, translate to `did-cli report` with the right flags:
+
+| User says | Command |
+|-----------|---------|
+| "hours on Crayon in Q1" | `did-cli report --customer "Crayon" --from 2026-01 --to 2026-03` |
+| "hours last week" | `did-cli report --week <last week number>` |
+| "hours on Project Alpha" | `did-cli report --project "Alpha"` |
+| "hours in March" | `did-cli report --from 2026-03 --to 2026-03` |
+| "hours this year" | `did-cli report --from 2026-01 --to 2026-12` |
+| "break down by project" | Run report, then group the JSON output by project |
+
+Always use the JSON output (no `--pretty`) so you can parse and present the data flexibly. Format the results in a clear, readable way adapted to what the user asked for - totals, breakdowns by customer/project, weekly summaries, etc.
+
+For date math:
+- "last week" = current ISO week minus 1
+- "Q1" = --from YYYY-01 --to YYYY-03
+- "Q2" = --from YYYY-04 --to YYYY-06
+- "Q3" = --from YYYY-07 --to YYYY-09
+- "Q4" = --from YYYY-10 --to YYYY-12
+- "this month" = --from YYYY-MM --to YYYY-MM (current month)
+
+### 3. Check status / time bank
+
+When the user asks about time bank, vacation, or general status:
+
+```bash
+did-cli status
+```
+
+Parse the JSON and present: time bank balance, vacation days (used/remaining), user info.
+
+## Handling ambiguity
+
+If the user's query is ambiguous (e.g. a project name that could match multiple customers), run the report and check the results. If results span multiple customers/projects, ask the user to clarify.
+
+## Error handling
+
+- **401 / expired cookie**: Tell the user to refresh their cookie: `did-cli config --cookie "<new value>"`
+- **Empty results**: Report that no matching entries were found for the given filters
+- **CLI not found**: Walk through setup steps (see prerequisites)
+
+## Output formatting
+
+- For totals: single line with the number
+- For breakdowns: markdown table
+- For status: structured summary with labels
+- Match the granularity to what the user asked for - don't over-explain simple queries


### PR DESCRIPTION
## Summary

- Users can create personal API tokens from Settings > API tokens, without needing admin privileges
- PATs carry user identity (`userId`, `tokenSource`) so actions are attributed to the user but distinguishable from interactive sessions
- Admins can view and revoke any user's PATs from the existing Admin > API Tokens page
- Tenant-level kill switch (`security.personalAccessTokensEnabled`) in Subscription Settings to disable PAT creation
- Token displayed inline with copy-to-clipboard after creation, persists until panel is dismissed

## Changes

**Server:**
- `ApiToken` type extended with `type` and `userId` fields
- `RequestContext` gains `tokenSource` property; `handleTokenAuthentication` populates `userId` for PATs
- New `PersonalAccessTokenResolver` with permission subset enforcement and tenant setting check
- `ApiTokenService.deleteToken` supports user-scoped deletion

**Client:**
- New "API tokens" tab in User Settings (hidden when tenant setting is off)
- Token creation form (name, expiry, permissions picker)
- Admin API Tokens page shows token type column
- i18n keys for English and Norwegian

## Test plan

- [ ] Create a PAT as a regular user via Settings > API tokens
- [ ] Verify the token is displayed inline and can be copied
- [ ] Use the PAT as a Bearer token in a GraphQL request - verify `userId` is populated
- [ ] Verify PAT permissions are enforced (cannot grant permissions you don't have)
- [ ] As admin, verify PATs appear in Admin > API Tokens with "Personal" type
- [ ] Toggle off "Allow personal access tokens" in Subscription Settings > Security
- [ ] Verify the API tokens tab is hidden for users when disabled
- [ ] Delete a PAT and verify it no longer authenticates