### PR TITLE
fix: fallback to PAT actor metadata

### DIFF
--- a/server/graphql/resolvers/subscription/SubscriptionResolver.ts
+++ b/server/graphql/resolvers/subscription/SubscriptionResolver.ts
@@ -108,7 +108,10 @@ export class SubscriptionResolver {
     }
   }
 
-  @Authorized<IAuthOptions>({ scope: PermissionScope.INVITE_EXTERNAL_USERS })
+  @Authorized<IAuthOptions>({
+    scope: PermissionScope.INVITE_EXTERNAL_USERS,
+    requiresUserContext: true
+  })
   @Mutation(() => BaseResult, { description: 'Invite external user' })
   async inviteExternalUser(
     @Ctx() context: RequestContext,

--- a/server/graphql/resolvers/subscription/SubscriptionResolver.ts
+++ b/server/graphql/resolvers/subscription/SubscriptionResolver.ts
@@ -121,7 +121,7 @@ export class SubscriptionResolver {
         ...invitation,
         status: 'pending',
         invitedAt: new Date(),
-        invitedBy: context.user.id,
+        invitedBy: context.user?.id || context.userId,
         provider: 'microsoft',
         startPage: '/reports',
         theme: 'auto',

--- a/server/services/mongo/document/MongoDocumentService.ts
+++ b/server/services/mongo/document/MongoDocumentService.ts
@@ -287,8 +287,8 @@ export class MongoDocumentService<T> {
         ...document,
         createdAt: new Date(),
         updatedAt: new Date(),
-        createdBy: document.createdBy ?? this.actorUserId,
-        updatedBy: document.updatedBy ?? this.actorUserId
+        createdBy: document_.createdBy ?? this.actorUserId,
+        updatedBy: document_.updatedBy ?? this.actorUserId
       } as OptionalId<T>
     ) as Promise<InsertOneWriteOpResult<WithId<T>>>
   }
@@ -307,7 +307,7 @@ export class MongoDocumentService<T> {
       $set: {
         ...document,
         updatedAt: new Date(),
-        updatedBy: document.updatedBy ?? this.actorUserId
+        updatedBy: document_.updatedBy ?? this.actorUserId
       }
     })
   }

--- a/server/services/mongo/document/MongoDocumentService.ts
+++ b/server/services/mongo/document/MongoDocumentService.ts
@@ -287,8 +287,8 @@ export class MongoDocumentService<T> {
         ...document,
         createdAt: new Date(),
         updatedAt: new Date(),
-        createdBy: this.actorUserId,
-        updatedBy: this.actorUserId
+        createdBy: document.createdBy ?? this.actorUserId,
+        updatedBy: document.updatedBy ?? this.actorUserId
       } as OptionalId<T>
     ) as Promise<InsertOneWriteOpResult<WithId<T>>>
   }
@@ -307,7 +307,7 @@ export class MongoDocumentService<T> {
       $set: {
         ...document,
         updatedAt: new Date(),
-        updatedBy: this.actorUserId
+        updatedBy: document.updatedBy ?? this.actorUserId
       }
     })
   }

--- a/server/services/mongo/reportLink.ts
+++ b/server/services/mongo/reportLink.ts
@@ -64,7 +64,7 @@ export class ReportLinkService extends MongoDocumentService<ReportLink> {
       const result = await this.insert({
         _id: this._generateId(reportLink),
         ...reportLink,
-        createdBy: this.context.user.displayName
+        createdBy: this.context.user?.displayName || this.context.userId
       })
       return result
     } catch (error) {
@@ -81,7 +81,7 @@ export class ReportLinkService extends MongoDocumentService<ReportLink> {
     try {
       await this.update(_.pick(reportLink, 'name'), {
         ...reportLink,
-        updatedBy: this.context.user.displayName
+        updatedBy: this.context.user?.displayName || this.context.userId
       })
     } catch (error) {
       throw error

--- a/server/services/mongo/subscription.ts
+++ b/server/services/mongo/subscription.ts
@@ -213,7 +213,7 @@ export class SubscriptionService extends MongoDocumentService<Subscription> {
           lockedPeriods.push({
             periodId,
             reason,
-            lockedBy: this.context.user.id,
+            lockedBy: this.context.user?.id || this.context.userId,
             lockedAt: new Date()
           })
         }

--- a/server/services/mongo/subscription.ts
+++ b/server/services/mongo/subscription.ts
@@ -213,7 +213,7 @@ export class SubscriptionService extends MongoDocumentService<Subscription> {
           lockedPeriods.push({
             periodId,
             reason,
-            lockedBy: this.context.user?.id || this.context.userId,
+            lockedBy: this.actorUserId,
             lockedAt: new Date()
           })
         }


### PR DESCRIPTION
## Summary
- use `userId` as a fallback actor when PAT-authenticated requests lock periods
- use the same fallback when PAT-authenticated requests invite external users
- avoid PAT-scoped report-link writes failing on missing interactive `user.displayName`

## Validation
- `npm run lint`
- `npm run build:server`