### PR TITLE
fix: reports UX improvements and bug fixes

### DIFF
--- a/client/components/FormControl/ProjectPickerControl/ProjectPickerControl.module.scss
+++ b/client/components/FormControl/ProjectPickerControl/ProjectPickerControl.module.scss
@@ -11,6 +11,10 @@
     }
   }
 
+  .selectedTags {
+    margin-top: 6px;
+  }
+
   .openPickerButton {
     margin: 12px 0;
   }

--- a/client/components/FormControl/ProjectPickerControl/ProjectPickerControl.tsx
+++ b/client/components/FormControl/ProjectPickerControl/ProjectPickerControl.tsx
@@ -1,4 +1,10 @@
 import { SearchProject } from 'components/SearchProject'
+import {
+  InteractionTag,
+  InteractionTagPrimary,
+  InteractionTagSecondary,
+  TagGroup
+} from '@fluentui/react-components'
 import React from 'react'
 import { FormInputControlComponent } from '../types'
 import styles from './ProjectPickerControl.module.scss'
@@ -12,23 +18,46 @@ import _ from 'lodash'
 export const ProjectPickerControl: FormInputControlComponent<
   IProjectPickerControlProps
 > = (props) => {
-  const { onSelected, filterFunc } = useProjectPickerControl(props)
+  const { onSelected, onRemove, filterFunc } = useProjectPickerControl(props)
+  const selectedValues = props.multiple
+    ? (Array.isArray(props.model.value(props.name))
+        ? props.model.value(props.name)
+        : [])
+    : null
+
   return (
-    <SearchProject
-      {..._.pick(
-        props,
-        'hidden',
-        'label',
-        'description',
-        'placeholder',
-        'disabledText',
-        'maxSuggestions',
-        'onRenderText'
+    <div className={styles.projectPickerControl}>
+      <SearchProject
+        {..._.pick(
+          props,
+          'hidden',
+          'label',
+          'description',
+          'placeholder',
+          'disabledText',
+          'maxSuggestions',
+          'onRenderText'
+        )}
+        filterFunc={props.all ? undefined : filterFunc}
+        onSelected={onSelected}
+        selectedKey={props.multiple ? undefined : props.model.value(props.name)}
+      />
+      {selectedValues && selectedValues.length > 0 && (
+        <TagGroup
+          className={styles.selectedTags}
+          onDismiss={(_, { value }) => onRemove(value)}
+        >
+          {selectedValues.map((value: string) => (
+            <InteractionTag key={value} value={value}>
+              <InteractionTagPrimary hasSecondaryAction>
+                {value}
+              </InteractionTagPrimary>
+              <InteractionTagSecondary />
+            </InteractionTag>
+          ))}
+        </TagGroup>
       )}
-      filterFunc={props.all ? undefined : filterFunc}
-      onSelected={onSelected}
-      selectedKey={props.model.value(props.name)}
-    />
+    </div>
   )
 }
 

--- a/client/components/FormControl/ProjectPickerControl/types.ts
+++ b/client/components/FormControl/ProjectPickerControl/types.ts
@@ -1,4 +1,5 @@
 import { ISearchProjectProps } from 'components/SearchProject'
+import { Project } from 'types'
 import { HTMLAttributes } from 'react'
 import { FormInputControlBase } from '../types'
 
@@ -18,4 +19,15 @@ export interface IProjectPickerControlProps
    * Search all projects skipping all kinds of filters.
    */
   all?: boolean
+
+  /**
+   * Allow selecting multiple projects. When true, the selected
+   * values are stored as an array.
+   */
+  multiple?: boolean
+
+  /**
+   * Custom function to transform the value of the selected project.
+   */
+  transformValue?: (project: Project) => any
 }

--- a/client/components/FormControl/ProjectPickerControl/useProjectPickerControl.tsx
+++ b/client/components/FormControl/ProjectPickerControl/useProjectPickerControl.tsx
@@ -9,7 +9,27 @@ import { IProjectPickerControlProps } from './types'
  */
 export function useProjectPickerControl(props: IProjectPickerControlProps) {
   const onSelected: ISearchProjectProps['onSelected'] = (project) => {
-    props.model.set(props.name, project?.tag ?? null)
+    if (props.multiple) {
+      const value = props.transformValue
+        ? props.transformValue(project)
+        : (project?.tag ?? null)
+      const current = props.model.value(props.name) ?? []
+      const values = Array.isArray(current) ? current : []
+      if (value && !values.includes(value)) {
+        props.model.set(props.name, [...values, value])
+      }
+    } else {
+      props.model.set(props.name, project?.tag ?? null)
+    }
+  }
+
+  const onRemove = (valueToRemove: string) => {
+    const current = props.model.value(props.name) ?? []
+    const values = Array.isArray(current) ? current : []
+    props.model.set(
+      props.name,
+      values.filter((v: string) => v !== valueToRemove)
+    )
   }
 
   const filterFunc: ISearchProjectProps['filterFunc'] = (project) => {
@@ -18,5 +38,5 @@ export function useProjectPickerControl(props: IProjectPickerControlProps) {
       project?.customerKey === props.model.value('customerKey')
     )
   }
-  return { onSelected, filterFunc }
+  return { onSelected, onRemove, filterFunc }
 }

--- a/client/components/List/ViewColumnsPanel/ViewColumnsPanel.tsx
+++ b/client/components/List/ViewColumnsPanel/ViewColumnsPanel.tsx
@@ -1,5 +1,5 @@
 import { Panel } from 'components/Panel'
-import React, { FC } from 'react'
+import React, { FC, useEffect } from 'react'
 import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd'
 import { useTranslation } from 'react-i18next'
 import { useListContext } from '../context'
@@ -16,16 +16,51 @@ import styles from './ViewColumnsPanel.module.scss'
 export const ViewColumnsPanel: FC = () => {
   const { t } = useTranslation()
   const context = useListContext()
-  const { columns, toggleColumnVisibility, reorderColumns } =
-    useViewColumnsPanel()
+  const {
+    columns,
+    toggleColumnVisibility,
+    reorderColumns,
+    takeSnapshot,
+    cancel,
+    reset
+  } = useViewColumnsPanel()
   const { handleDragEnd } = useDragAndDrop(reorderColumns)
+  const isOpen = context.state.viewColumnsPanel?.open
+
+  useEffect(() => {
+    if (isOpen) takeSnapshot()
+  }, [isOpen])
+
+  const dismiss = () => context.dispatch(TOGGLE_VIEW_COLUMNS_PANEL())
+
+  const onCancel = () => {
+    cancel()
+    dismiss()
+  }
 
   return (
     <Panel
       {...context.state.viewColumnsPanel}
-      onDismiss={() => context.dispatch(TOGGLE_VIEW_COLUMNS_PANEL())}
+      onDismiss={dismiss}
       title={t('list.viewColumnsPanel.title')}
       description={t('list.viewColumnsPanel.description')}
+      headerActions={[
+        {
+          text: t('common.resetButtonLabel', { defaultValue: 'Reset' }),
+          appearance: 'subtle',
+          onClick: reset
+        },
+        {
+          text: t('common.save'),
+          appearance: 'primary',
+          onClick: dismiss
+        },
+        {
+          text: t('common.cancelButtonLabel'),
+          appearance: 'subtle',
+          onClick: onCancel
+        }
+      ]}
     >
       <div className={styles.columnsContainer}>
         <DragDropContext onDragEnd={handleDragEnd}>

--- a/client/components/List/ViewColumnsPanel/hooks/useViewColumnsPanel.ts
+++ b/client/components/List/ViewColumnsPanel/hooks/useViewColumnsPanel.ts
@@ -14,6 +14,7 @@ export const useViewColumnsPanel = () => {
   const [columns, setColumns] = useState<IListColumn[]>(context.props.columns)
   const persist = useViewColumnsPersist(columns)
   const lastSyncSignature = useRef<string>('')
+  const snapshotRef = useRef<IListColumn[]>(null)
   const dispatchRef = useRef(context.dispatch)
   dispatchRef.current = context.dispatch
 
@@ -43,6 +44,30 @@ export const useViewColumnsPanel = () => {
       persist.update()
     }
   }, [columns, persist])
+
+  /**
+   * Take a snapshot of the current column state when the panel opens
+   */
+  const takeSnapshot = () => {
+    snapshotRef.current = columns.map((c) => ({ ...c, data: { ...c.data } }))
+  }
+
+  /**
+   * Revert to the snapshot taken when the panel opened
+   */
+  const cancel = () => {
+    if (snapshotRef.current) {
+      setColumns(snapshotRef.current)
+      snapshotRef.current = null
+    }
+  }
+
+  /**
+   * Reset columns to their original definitions (default visibility and order)
+   */
+  const reset = () => {
+    setColumns(context.props.columns)
+  }
 
   /**
    * Toggle the visibility of a column
@@ -77,6 +102,9 @@ export const useViewColumnsPanel = () => {
   return {
     columns,
     toggleColumnVisibility,
-    reorderColumns
+    reorderColumns,
+    takeSnapshot,
+    cancel,
+    reset
   }
 }

--- a/client/components/List/hooks/useColumnWidthPersist.ts
+++ b/client/components/List/hooks/useColumnWidthPersist.ts
@@ -4,6 +4,12 @@ import { useBrowserStorage } from 'hooks'
 import { useCallback, useMemo, useRef, useEffect } from 'react'
 
 type PersistedColumnWidths = Record<string, number>
+
+/**
+ * Maximum reasonable column width in pixels. Any persisted or computed
+ * width above this is treated as corrupted data and clamped.
+ */
+const MAX_COLUMN_WIDTH = 2000
 type StorageLike = {
   readonly length: number
   clear: () => void
@@ -94,8 +100,9 @@ export function useColumnWidthPersist(
       const defaultWidth = Math.max(minWidth, defaultWidthRaw)
       const idealWidth = col.idealWidth ?? defaultWidth
       const persistedWidth = persistedWidths[col.key]
+      const effectiveMax = col.maxWidth ?? MAX_COLUMN_WIDTH
       const baseWidth = persistedWidth ?? idealWidth
-      const clamped = Math.max(minWidth, baseWidth)
+      const clamped = Math.min(effectiveMax, Math.max(minWidth, baseWidth))
       map[col.key] = clamped
     }
     return map
@@ -111,8 +118,8 @@ export function useColumnWidthPersist(
           : undefined
       const clampWidth = (value: number) => {
         const clampedMin = Math.max(minWidth, value)
-        if (maxWidth === undefined || maxWidth === null) return clampedMin
-        return Math.min(maxWidth, clampedMin)
+        const effectiveMax = maxWidth ?? MAX_COLUMN_WIDTH
+        return Math.min(effectiveMax, clampedMin)
       }
       const defaultWidthRaw = col.defaultWidth ?? col.minWidth ?? 100
       const defaultWidth = clampWidth(
@@ -146,8 +153,8 @@ export function useColumnWidthPersist(
           ? maxRaw
           : undefined
       const clampedMin = Math.max(min, data.width)
-      const clamped =
-        max === undefined || max === null ? clampedMin : Math.min(max, clampedMin)
+      const effectiveMax = max ?? MAX_COLUMN_WIDTH
+      const clamped = Math.min(effectiveMax, clampedMin)
       setPersistedWidths(prev => ({
         ...prev,
         [data.columnId]: clamped
@@ -165,7 +172,8 @@ export function useColumnWidthPersist(
       for (const k in prev) {
         if (allowed.has(k)) {
           const mw = minWidthByCol[k] ?? 0
-          const v = Math.max(mw, prev[k])
+          const colMaxWidth = columns.find(c => c.key === k)?.maxWidth ?? MAX_COLUMN_WIDTH
+          const v = Math.min(colMaxWidth, Math.max(mw, prev[k]))
           next[k] = v
           if (v !== prev[k]) changed = true
         } else {

--- a/client/pages/Reports/CustomQueryTab/CustomQueryTab.module.scss
+++ b/client/pages/Reports/CustomQueryTab/CustomQueryTab.module.scss
@@ -5,8 +5,7 @@
     padding: 16px;
 
     .filterCriterias {
-        width: 500px;
-        transition: width 0.5s ease-in-out;
+        width: 100%;
 
         .header {
             cursor: pointer;
@@ -24,8 +23,6 @@
         }
 
         &.isCollapsed {
-            width: 100%;
-            transition: width 0.5s ease-in-out;
             .subHeader,
             .formSection,
             .actions {

--- a/client/pages/Reports/CustomQueryTab/CustomQueryTab.tsx
+++ b/client/pages/Reports/CustomQueryTab/CustomQueryTab.tsx
@@ -153,9 +153,11 @@ export const CustomQueryTab: TabComponent = (props) => {
 
           <div className={styles.formRow}>
             <ProjectPickerControl
-              {...formControl.register('projectId')}
+              {...formControl.register('projectIds')}
               label={t('common.projectIdLabel')}
               all
+              multiple
+              transformValue={(project) => project?.tag}
               maxSuggestions={8}
             />
           </div>

--- a/client/pages/Reports/SummaryView/hooks/useColumns.tsx
+++ b/client/pages/Reports/SummaryView/hooks/useColumns.tsx
@@ -1,4 +1,4 @@
-import $date from 'DateUtils'
+import { DateObject } from 'DateUtils'
 import {
   IListColumn,
   IListColumnData,
@@ -11,24 +11,33 @@ import { ColumnHeader } from '../ColumnHeader'
 import { PeriodColumn } from '../PeriodColumn'
 
 /**
+ * Format a date range as a compact string, e.g. "23-29.03"
+ */
+function formatCompactDateRange(startDate: any, endDate: any): string {
+  const start = new DateObject(startDate)
+  const end = new DateObject(endDate)
+  const startDay = start.format('D')
+  const endDay = end.format('D')
+  const endMonth = end.format('MM')
+
+  if (start.isSameMonth(end)) {
+    return `${startDay}-${endDay}.${endMonth}`
+  }
+  const startMonth = start.format('MM')
+  return `${startDay}.${startMonth}-${endDay}.${endMonth}`
+}
+
+/**
  * Columns hook for SummaryView
  */
 export function useColumns(): IListColumn[] {
   const { queryPreset } = useReportsContext()
   const periods = (queryPreset?.periods ?? []) as any[]
-  const userColumn = useUserListColumn()
+  const userColumn = useUserListColumn(undefined, { minWidth: 190 })
   const columns: IListColumn[] = [userColumn]
   for (const p of periods) {
     const data: IListColumnData = {}
-    data.subText = $date.getTimespanString({
-      startDate: p.startDate,
-      endDate: p.endDate,
-      monthFormat: 'MMM',
-      includeMonth: {
-        startDate: false,
-        endDate: true
-      }
-    })
+    data.subText = formatCompactDateRange(p.startDate, p.endDate)
     data.onRenderColumnHeader = ({
       column,
       className

--- a/client/pages/Reports/hooks/useReportsExcelExportCommand.ts
+++ b/client/pages/Reports/hooks/useReportsExcelExportCommand.ts
@@ -169,7 +169,7 @@ export function useReportsExcelExportCommand(props: IReportsListProps) {
   const hasItems = (props.items ?? []).length > 0
 
   const commandBarItem: ListCommandBarItem = isCustomQuery
-    ? hasItems
+    ? (hasItems
       ? {
           key: 'EXPORT_TO_EXCEL_DIRECT',
           text: t('reports.exportToExcel'),
@@ -177,7 +177,7 @@ export function useReportsExcelExportCommand(props: IReportsListProps) {
           disabled: false,
           iconName: 'ExcelDocument'
         }
-      : undefined
+      : undefined)
     : {
         key: 'EXPORT_TO_EXCEL_PROGRESS',
         text: isExporting ? progressMessage : t('reports.exportToExcel'),

--- a/client/pages/Reports/hooks/useReportsExcelExportCommand.ts
+++ b/client/pages/Reports/hooks/useReportsExcelExportCommand.ts
@@ -3,14 +3,58 @@ import { useTranslation } from 'react-i18next'
 import { useReportsContext } from '../context'
 import { IReportsListProps } from '../ReportsList/types'
 import { useColumns } from '../ReportsList/columns/useColumns'
-import { useBrowserStorage } from 'hooks'
 import _ from 'lodash'
-import { ListCommandBarItem, ListFilterState } from 'components/List/types'
+import { IListColumn, ListCommandBarItem, ListFilterState } from 'components/List/types'
 import report_custom from 'pages/Reports/queries/report-custom.gql'
 
 type PersistedColumn = {
   key: string
   hidden: boolean
+}
+
+const PERSISTED_COLUMNS_KEY = 'reportslist_columns'
+
+/**
+ * Read persisted column state directly from localStorage.
+ * This avoids stale React state from `useBrowserStorage` which
+ * only reads once at mount time.
+ */
+function readPersistedColumns(): PersistedColumn[] {
+  try {
+    const raw = window.localStorage.getItem(PERSISTED_COLUMNS_KEY)
+    return raw ? JSON.parse(raw) : []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Apply persisted column visibility and ordering to column definitions.
+ */
+function applyPersistedColumns(
+  columns: IListColumn[],
+  persisted: PersistedColumn[]
+): IListColumn[] {
+  if (_.isEmpty(persisted)) return columns
+  return [...columns]
+    .sort((a, b) => {
+      const aIndex = persisted.findIndex((c) => c.key === a.key)
+      const bIndex = persisted.findIndex((c) => c.key === b.key)
+      return aIndex - bIndex
+    })
+    .map((column) => {
+      const persistedColumn = persisted.find((c) => c.key === column.key)
+      return {
+        ...column,
+        data: {
+          ...column.data,
+          hidden:
+            persistedColumn === undefined
+              ? column?.data?.hidden
+              : persistedColumn.hidden
+        }
+      }
+    })
 }
 
 function buildFilterQuery(filterState?: ListFilterState) {
@@ -52,10 +96,6 @@ export function useReportsExcelExportCommand(props: IReportsListProps) {
   const { t } = useTranslation()
   const context = useReportsContext()
   const columns = useColumns()
-  const [persistedColumns] = useBrowserStorage<PersistedColumn[]>({
-    key: 'reportslist_columns',
-    initialValue: []
-  })
 
   const appliedFilterQuery = buildFilterQuery(context.state?.appliedFilterState)
   const hasAppliedFilters = Object.keys(appliedFilterQuery).length > 0
@@ -66,29 +106,19 @@ export function useReportsExcelExportCommand(props: IReportsListProps) {
     'current_year'
   ].includes(context.queryPreset?.id)
 
-  const exportColumns = _.isEmpty(persistedColumns)
-    ? columns
-    : [...columns]
-        .sort((a, b) => {
-          const aIndex = persistedColumns.findIndex((c) => c.key === a.key)
-          const bIndex = persistedColumns.findIndex((c) => c.key === b.key)
-          return aIndex - bIndex
-        })
-        .map((column) => {
-          const persistedColumn = persistedColumns.find(
-            (c) => c.key === column.key
-          )
-          return {
-            ...column,
-            data: {
-              ...column.data,
-              hidden:
-                persistedColumn === undefined
-                  ? column?.data?.hidden
-                  : persistedColumn.hidden
-            }
-          }
-        })
+  /**
+   * Build export columns by reading persisted state fresh from localStorage
+   * every time. This ensures changes made in the ViewColumnsPanel are
+   * always reflected in the export, even without a page reload.
+   */
+  const getExportColumns = () => {
+    const persisted = readPersistedColumns()
+    return applyPersistedColumns(columns, persisted)
+  }
+
+  // For the progress-based export hook we still need a static columns value
+  // at render time. Read fresh from localStorage each render.
+  const exportColumns = applyPersistedColumns(columns, readPersistedColumns())
 
   // Determine if this is a large dataset query
   const isLargeDataset = ['current_year', 'last_year'].includes(
@@ -114,30 +144,55 @@ export function useReportsExcelExportCommand(props: IReportsListProps) {
       presetId: context.queryPreset?.id // Pass preset ID to generate correct query parameters
     })
 
-  if (!context.queryPreset) {
-    return {
-      commandBarItem: undefined,
-      menuItem: undefined,
-      progress: null,
-      progressMessage: ''
-    }
+  // For custom queries (no queryPreset), provide a direct export using
+  // already-loaded items instead of re-fetching from the server.
+  const onDirectExport = async () => {
+    const items = props.items ?? []
+    if (items.length === 0) return
+    // Read fresh from localStorage at export time
+    const freshColumns = getExportColumns().filter(
+      (col) => !col?.data?.hidden
+    )
+    const { exportExcel } = await import('utils/exportExcel')
+    const format = (await import('string-format')).default
+    const formattedFileName = format(
+      props.exportFileName || 'TimeEntries-Custom-{0}.xlsx',
+      new Date().toDateString().split(' ').join('-')
+    )
+    await exportExcel(items, {
+      columns: freshColumns,
+      fileName: formattedFileName
+    })
   }
 
-  const commandBarItem: ListCommandBarItem = {
-    key: 'EXPORT_TO_EXCEL_PROGRESS',
-    text: isExporting ? progressMessage : t('reports.exportToExcel'),
-    onClick: () => {
-      exportAllData()
-    },
-    disabled: isExporting,
-    iconName: isExporting ? 'Progress' : 'ExcelDocument'
-  }
+  const isCustomQuery = !context.queryPreset
+  const hasItems = (props.items ?? []).length > 0
+
+  const commandBarItem: ListCommandBarItem = isCustomQuery
+    ? hasItems
+      ? {
+          key: 'EXPORT_TO_EXCEL_DIRECT',
+          text: t('reports.exportToExcel'),
+          onClick: onDirectExport,
+          disabled: false,
+          iconName: 'ExcelDocument'
+        }
+      : undefined
+    : {
+        key: 'EXPORT_TO_EXCEL_PROGRESS',
+        text: isExporting ? progressMessage : t('reports.exportToExcel'),
+        onClick: () => {
+          exportAllData()
+        },
+        disabled: isExporting,
+        iconName: isExporting ? 'Progress' : 'ExcelDocument'
+      }
 
   return {
     commandBarItem,
-    progress,
-    progressMessage,
-    isExporting,
-    exportAllData
+    progress: isCustomQuery ? null : progress,
+    progressMessage: isCustomQuery ? '' : progressMessage,
+    isExporting: isCustomQuery ? false : isExporting,
+    exportAllData: isCustomQuery ? onDirectExport : exportAllData
   }
 }

--- a/server/graphql/resolvers/reports/types.ts
+++ b/server/graphql/resolvers/reports/types.ts
@@ -94,9 +94,17 @@ export type ReportsQueryPreset =
 export class ReportsQuery {
   /**
    * ID of the project to filter on.
+   *
+   * @deprecated Use `projectIds` instead.
    */
   @Field({ nullable: true })
   projectId?: string
+
+  /**
+   * IDs of the projects to filter on.
+   */
+  @Field(() => [String], { nullable: true })
+  projectIds?: string[]
 
   /**
    * IDs of the users to filter on.

--- a/server/services/report/ReportService.ts
+++ b/server/services/report/ReportService.ts
@@ -466,9 +466,11 @@ export class ReportService {
         ...presetQuery,
         ..._.pick(
           {
-            projectId: {
-              $eq: queryWithoutPagination.projectId
-            },
+            projectId: !_.isEmpty(queryWithoutPagination.projectIds)
+              ? { $in: queryWithoutPagination.projectIds }
+              : queryWithoutPagination.projectId
+                ? { $eq: queryWithoutPagination.projectId }
+                : undefined,
             userId: {
               $in: queryWithoutPagination.userIds
             },
@@ -482,7 +484,8 @@ export class ReportService {
           },
           [
             ...Object.keys(queryWithoutPagination),
-            !_.isEmpty(queryWithoutPagination?.userIds) && 'userId'
+            !_.isEmpty(queryWithoutPagination?.userIds) && 'userId',
+            !_.isEmpty(queryWithoutPagination?.projectIds) && 'projectId'
           ]
         )
       },

--- a/server/services/report/ReportService.ts
+++ b/server/services/report/ReportService.ts
@@ -466,11 +466,11 @@ export class ReportService {
         ...presetQuery,
         ..._.pick(
           {
-            projectId: !_.isEmpty(queryWithoutPagination.projectIds)
-              ? { $in: queryWithoutPagination.projectIds }
-              : queryWithoutPagination.projectId
+            projectId: _.isEmpty(queryWithoutPagination.projectIds)
+              ? (queryWithoutPagination.projectId
                 ? { $eq: queryWithoutPagination.projectId }
-                : undefined,
+                : undefined)
+              : { $in: queryWithoutPagination.projectIds },
             userId: {
               $in: queryWithoutPagination.userIds
             },

--- a/webpack/config.js
+++ b/webpack/config.js
@@ -35,6 +35,15 @@ const config = {
     hints: false,
     maxEntrypointSize: 512000,
     maxAssetSize: 512000
+  },
+  watchOptions: {
+    // Polling is required inside Docker on macOS (inotify events don't
+    // propagate from the host volume into the container).
+    poll: 2000,
+    aggregateTimeout: 500,
+    // Ignore node_modules and the HtmlWebpackPlugin output directory —
+    // without this, writing index.hbs triggers an infinite rebuild loop.
+    ignored: [/node_modules/, /server[\\/]views/, /server[\\/]public/]
   }
 }
 

--- a/webpack/config.js
+++ b/webpack/config.js
@@ -43,7 +43,7 @@ const config = {
     aggregateTimeout: 500,
     // Ignore node_modules and the HtmlWebpackPlugin output directory —
     // without this, writing index.hbs triggers an infinite rebuild loop.
-    ignored: [/node_modules/, /server[\\/]views/, /server[\\/]public/]
+    ignored: ['**/node_modules/**', '**/server/views/**', '**/server/public/**']
   }
 }
 


### PR DESCRIPTION
## Summary
- **ViewColumnsPanel**: Add Reset, Save, Cancel buttons at panel top with snapshot/revert support
- **Excel export**: Fix stale column state by reading localStorage directly at export time instead of via `useBrowserStorage` (which only reads once at mount)
- **Custom query report**: Add Excel export, full-width filter card, multi-select project filter using `InteractionTag` pattern
- **Summary report**: Compact date headers (`23-29.03` instead of `23 - 29 Mar`), 190px employee column
- **DataGrid**: Cap column widths at 2000px to prevent runaway last-column sizing
- **Server**: Add `projectIds` array field to `ReportsQuery` for multi-project filtering
- **Webpack**: Add watch polling for Docker macOS volume compatibility

## Test plan
- [ ] Open reports, edit view columns, click Reset - verify it restores default column set (not all visible)
- [ ] Change view columns, then export to Excel - verify exported columns match the selection
- [ ] Run a custom query report and verify Export to Excel button appears and works
- [ ] Verify custom query filter card is full width when both expanded and collapsed
- [ ] Select multiple projects in custom query filter, verify X buttons dismiss tags
- [ ] Check summary report date headers show compact format and employee column is wider
- [ ] Verify no DataGrid column grows beyond 2000px