### PR TITLE
feat: unify excel export columns with list visibility

### DIFF
--- a/client/components/List/ListHeader/ListToolbar/useExcelExportCommand.ts
+++ b/client/components/List/ListHeader/ListToolbar/useExcelExportCommand.ts
@@ -30,7 +30,7 @@ export function useExcelExportCommand() {
         new Date().toDateString().split(' ').join('-')
       )
       exportExcel(context.state.items, {
-        columns: context.props.columns,
+        columns: context.state.columns,
         fileName
       })
     },

--- a/client/components/List/types/IListColumnData.ts
+++ b/client/components/List/types/IListColumnData.ts
@@ -45,11 +45,6 @@ export interface IListColumnData {
   excelRenderFunction?: (fieldValue: any) => string | number
 
   /**
-   * Hidden from Excel exports
-   */
-  hiddenFromExport?: boolean
-
-  /**
    * Is the column sortable?
    */
   isSortable?: boolean

--- a/client/pages/Reports/ReportsList/columns/definitions/DateTimeColumnOptions.ts
+++ b/client/pages/Reports/ReportsList/columns/definitions/DateTimeColumnOptions.ts
@@ -2,5 +2,5 @@ export type DateTimeColumnOptions = {
   key?: string
   name?: string
   template?: string
-  hiddenFromExport?: boolean
+  hidden?: boolean
 }

--- a/client/pages/Reports/ReportsList/columns/definitions/endDateTime.ts
+++ b/client/pages/Reports/ReportsList/columns/definitions/endDateTime.ts
@@ -11,12 +11,12 @@ export const endDateTimeColumn =
     key = 'endDateTime',
     name,
     template = 'MMM DD, HH:mm',
-    hiddenFromExport = false
+    hidden = false
   }: DateTimeColumnOptions = {}): CreateColumnDefFunction =>
   (t) =>
     createColumnDef<TimeEntry>(key, name ?? t('common.endTimeLabel'), {
       minWidth: 125,
       maxWidth: 125,
-      data: { excelColFormat: 'date', hidden: true, hiddenFromExport },
+      data: { excelColFormat: 'date', hidden },
       onRender: ({ endDateTime }) => $date.formatDate(endDateTime, template)
     })

--- a/client/pages/Reports/ReportsList/columns/definitions/period.ts
+++ b/client/pages/Reports/ReportsList/columns/definitions/period.ts
@@ -13,7 +13,7 @@ export const periodColumn: CreateColumnDefFunction = (t) =>
       description: t('reports.periodColumnDescription'),
       minWidth: 100,
       maxWidth: 100,
-      data: { hiddenFromExport: true }
+      data: { hidden: true }
     },
     (item) => `${item.week}/${item.month}/${item.year}`
   )

--- a/client/pages/Reports/ReportsList/columns/definitions/resource.displayName.tsx
+++ b/client/pages/Reports/ReportsList/columns/definitions/resource.displayName.tsx
@@ -11,7 +11,6 @@ type ResourceColumnOptions = {
   description?: string
   includeRoleDetails?: boolean
   hidden?: boolean
-  hiddenFromExport?: boolean
 }
 
 /**
@@ -23,8 +22,7 @@ export const resourceColumn =
     label,
     description,
     includeRoleDetails = false,
-    hidden = false,
-    hiddenFromExport = false
+    hidden = false
   }: ResourceColumnOptions = {}): CreateColumnDefFunction =>
   (t) =>
     createColumnDef<TimeEntry>(
@@ -39,7 +37,6 @@ export const resourceColumn =
           isGroupable: true,
           isFilterable: true,
           hidden,
-          hiddenFromExport,
           filterType: ResourceFilter
         }
       },

--- a/client/pages/Reports/ReportsList/columns/definitions/startDateTime.ts
+++ b/client/pages/Reports/ReportsList/columns/definitions/startDateTime.ts
@@ -12,12 +12,12 @@ export const startDateTimeColumn =
     key = 'startDateTime',
     name,
     template = 'MMM DD, HH:mm',
-    hiddenFromExport = false
+    hidden = false
   }: DateTimeColumnOptions = {}): CreateColumnDefFunction =>
   (t) =>
     createColumnDef<TimeEntry>(key, name ?? t('common.startTimeLabel'), {
       minWidth: 125,
       maxWidth: 125,
-      data: { excelColFormat: 'date', hidden: true, hiddenFromExport },
+      data: { excelColFormat: 'date', hidden },
       onRender: ({ startDateTime }) => $date.formatDate(startDateTime, template)
     })

--- a/client/pages/Reports/ReportsList/columns/definitions/startEndDateTime.ts
+++ b/client/pages/Reports/ReportsList/columns/definitions/startEndDateTime.ts
@@ -13,7 +13,7 @@ export const startEndDateTimeColumn: CreateColumnDefFunction = (t) =>
       minWidth: 125,
       maxWidth: 170,
       data: {
-        hiddenFromExport: true
+        hidden: true
       }
     },
     ({ startDateTime, endDateTime }) =>

--- a/client/pages/Reports/ReportsList/columns/useColumns.ts
+++ b/client/pages/Reports/ReportsList/columns/useColumns.ts
@@ -51,14 +51,14 @@ export function useColumns() {
       key: 'startDateTimeShort',
       name: t('common.startTimeLabel_MMM_DD'),
       template: 'MMM DD',
-      hiddenFromExport: true
+      hidden: true
     }),
     endDateTimeColumn(),
     endDateTimeColumn({
       key: 'endDateTimeShort',
       name: t('common.endTimeLabel_MMM_DD'),
       template: 'MMM DD',
-      hiddenFromExport: true
+      hidden: true
     }),
     resourceColumn(),
     resourceColumn({
@@ -66,8 +66,7 @@ export function useColumns() {
       label: t('common.employeeWithRoleLabel'),
       description: t('common.employeeWithRoleDescription'),
       includeRoleDetails: true,
-      hidden: true,
-      hiddenFromExport: true
+      hidden: true
     }),
     surnameColumn,
     givenNameColumn,

--- a/client/utils/exportExcel.ts
+++ b/client/utils/exportExcel.ts
@@ -72,7 +72,7 @@ export async function exportExcel(
   }
 
   const columns = options.columns.filter(
-    (column_) => !column_?.data?.hiddenFromExport
+    (column_) => !column_?.data?.hidden
   )
 
   const sheets = [


### PR DESCRIPTION
## Summary

- Drops the hardcoded `hiddenFromExport` column property. Excel export now uses the same visibility state the user controls via `ViewColumnsPanel` (gear icon), which is already persisted per list in localStorage. To change what lands in the sheet, toggle columns on/off in the panel - no code changes required.
- Generic `useExcelExportCommand` switched from `context.props.columns` (static defs) to `context.state.columns` (live user selection) so it honours the panel too. The Reports export hook already filtered by `data.hidden`, so behaviour there is unchanged.
- Cleans up Reports default columns: `startDateTimeShort`/`endDateTimeShort`, `startEndDateTime` and `period` are hidden by default (they duplicate the full date columns / week+month+year which are the canonical export fields). `startDateTime`/`endDateTime` now default to visible (previously hidden with `hiddenFromExport: false`), so the default list and export include full start/end timestamps out of the box.

## Why

The previous design offered no user-facing way to change which columns were exported - `hiddenFromExport` was hardcoded in column definitions. On Reports the default export was cluttered with overlapping/duplicate columns. Rather than add a second parallel column picker, reuse the existing `ViewColumnsPanel` as the single source of truth for "what the user cares about in this list".

## Files touched

- `client/utils/exportExcel.ts` - filter by `data.hidden` instead of `data.hiddenFromExport`
- `client/components/List/types/IListColumnData.ts` - remove `hiddenFromExport` field
- `client/components/List/ListHeader/ListToolbar/useExcelExportCommand.ts` - use `state.columns` (live) not `props.columns`
- `client/pages/Reports/ReportsList/columns/**` - drop `hiddenFromExport` parameter, adjust default visibility for the duplicate columns

## Test plan

- [ ] `npm run lint` clean, typecheck clean
- [ ] Reports page default view shows full start/end date columns and no duplicate short/period columns
- [ ] Exporting from Reports default view produces a sheet with the visible columns in order
- [ ] Toggle visibility + reorder via the columns panel, export again - sheet reflects changes
- [ ] Reload, export - persisted selection still applied
- [ ] Verify one other list with `exportFileName` still exports correctly, respecting the panel