### PR TITLE
Improve cache deduping and clearing; add Redis mock SCAN; adjust cache expiries

### DIFF
--- a/server/middleware/redis/index.ts
+++ b/server/middleware/redis/index.ts
@@ -74,5 +74,13 @@ export const redisMiddlware = redisHostname
       del: (
         _keys: string | string[],
         callback: (error?: Error | null, reply?: any) => void
-      ) => callback?.(null, 1)
+      ) => callback?.(null, 1),
+      scan: (
+        _cursor: string,
+        _matchLabel: string,
+        _pattern: string,
+        _countLabel: string,
+        _count: string,
+        callback: (error: Error | null, reply: [string, string[]]) => void
+      ) => callback(null, ['0', []])
     } as any)

--- a/server/services/cache.ts
+++ b/server/services/cache.ts
@@ -79,6 +79,7 @@ export type CacheOptions = {
  */
 @Service({ global: false })
 export class CacheService {
+  private _inFlight = new Map<string, Promise<any>>()
   /**
    * Constructor
    *
@@ -191,13 +192,14 @@ export class CacheService {
               scopedCacheKey
             )}.`
           )
-          resolve(null)
-        } else {
-          log(
-            `Retrieved cached value for key ${colors.magenta(scopedCacheKey)}.`
-          )
-          resolve(JSON.parse(reply) as T)
+          return resolve(null)
         }
+        if (reply == null) {
+          log(`Cache miss for key ${colors.magenta(scopedCacheKey)}.`)
+          return resolve(null)
+        }
+        log(`Cache hit for key ${colors.magenta(scopedCacheKey)}.`)
+        resolve(JSON.parse(reply) as T)
       })
     })
   }
@@ -251,23 +253,48 @@ export class CacheService {
     const pattern = `${this._getScopedCacheKey(key, CacheScope.GLOBAL, hash)}*`
     log(`Clearing cache for key ${colors.magenta(pattern)}...`)
     return new Promise((resolve) => {
-      redisMiddlware.keys(pattern, (_error, keys) => {
-        if (keys.length === 0) {
-          log(`No keys found for pattern ${colors.magenta(pattern)}.`)
-          return resolve(null)
-        } else {
-          log(
-            `Clearing ${colors.magenta(
-              keys.length.toString()
-            )} keys for pattern ${colors.magenta(pattern)}: ${colors.cyan(
-              keys.join(', ')
-            )}.`
-          )
-        }
-        redisMiddlware.del(keys, () => {
-          resolve(null)
-        })
-      })
+      const collectedKeys: string[] = []
+      const step = (cursor: string) => {
+        redisMiddlware.scan(
+          cursor,
+          'MATCH',
+          pattern,
+          'COUNT',
+          '200',
+          (error, reply) => {
+            if (error) {
+              log(
+                `SCAN failed for pattern ${colors.magenta(pattern)}: ${
+                  error.message
+                }`
+              )
+              return resolve(null)
+            }
+            const [nextCursor, keys] = (reply || ['0', []]) as [
+              string,
+              string[]
+            ]
+            if (keys?.length) {
+              collectedKeys.push(...keys)
+            }
+            if (nextCursor === '0') {
+              if (collectedKeys.length === 0) {
+                log(`No keys found for pattern ${colors.magenta(pattern)}.`)
+                return resolve(null)
+              }
+              log(
+                `Clearing ${colors.magenta(
+                  collectedKeys.length.toString()
+                )} keys for pattern ${colors.magenta(pattern)}.`
+              )
+              redisMiddlware.del(collectedKeys, () => resolve(null))
+              return
+            }
+            step(nextCursor)
+          }
+        )
+      }
+      step('0')
     })
   }
 
@@ -284,10 +311,25 @@ export class CacheService {
     { key, expiry = 60, scope, disabled = false, hash }: CacheOptions
   ) {
     if (disabled) return await asyncFunction()
-    const cachedValue: T = await this._get<T>({ key, scope, hash })
-    if (cachedValue) return cachedValue
-    const value: T = await asyncFunction()
-    await this._set({ key, scope, expiry, hash }, value)
-    return value
+    const scopedCacheKey = this._getScopedCacheKey(key, scope, hash)
+    const inFlight = this._inFlight.get(scopedCacheKey)
+    if (inFlight) {
+      return (await inFlight) as T
+    }
+    const run = (async () => {
+      const cachedValue: T = await this._get<T>({ key, scope, hash })
+      if (cachedValue !== null && cachedValue !== undefined) {
+        return cachedValue
+      }
+      const value: T = await asyncFunction()
+      await this._set({ key, scope, expiry, hash }, value)
+      return value
+    })()
+    this._inFlight.set(scopedCacheKey, run)
+    try {
+      return await run
+    } finally {
+      this._inFlight.delete(scopedCacheKey)
+    }
   }
 }

--- a/server/services/mongo/customer.ts
+++ b/server/services/mongo/customer.ts
@@ -97,7 +97,7 @@ export class CustomerService extends MongoDocumentService<Customer> {
           })
           return _customers
         },
-        { key: ['getcustomers', query] }
+        { key: ['getcustomers', query], hash: 'sha256' }
       )
     } catch (error) {
       throw error

--- a/server/services/mongo/project/ProjectService.ts
+++ b/server/services/mongo/project/ProjectService.ts
@@ -112,7 +112,7 @@ export class ProjectService extends MongoDocumentService<Project> {
   public getProjects(query?: FilterQuery<Project>): Promise<Project[]> {
     return this.cache.usingCache<Project[]>(() => this.find(query), {
       key: ['getprojects', query],
-      expiry: 30
+      expiry: 180
     })
   }
 

--- a/server/services/msgraph/MSGraphService.ts
+++ b/server/services/msgraph/MSGraphService.ts
@@ -321,7 +321,7 @@ export class MSGraphService {
       const cacheOptions: CacheOptions = {
         key: ['events', startDateTimeIso, endDateTimeIso],
         scope: CacheScope.USER,
-        expiry: 20,
+        expiry: 60,
         disabled: !cache
       }
       const events = await this._cache.usingCache(async () => {


### PR DESCRIPTION
### Motivation
- Prevent duplicate work when multiple requests ask for the same cache key by deduplicating in-flight cache loads.
- Replace blocking `KEYS` usage with non-blocking `SCAN` to safely clear cache patterns in large keyspaces.
- Ensure test environment Redis client supports `scan` operations used by the new clear implementation.
- Adjust cache expiration and key hashing for more stable cache behavior for customers, projects and calendar events.

### Description
- Added an `_inFlight` `Map` to `CacheService` and updated `usingCache` to reuse in-flight promises and remove them when resolved.
- Fixed `_get` to handle errors correctly, log cache hits/misses and return `null` when the Redis reply is missing.
- Reimplemented `clear` to iterate keys using Redis `SCAN` (cursor-based), collect matches, and delete them in bulk instead of using `KEYS`.
- Extended the test Redis middleware mock with a no-op `scan` implementation returning `['0', []]`.
- Enabled hashing for `getCustomers` cache keys with `sha256` and increased `getProjects` expiry from `30` to `180` seconds and `getEvents` expiry from `20` to `60` seconds.

### Testing
- Ran the unit test suite including cache-related tests for `usingCache`, `_get`, and `clear`, and they all passed.
- Executed integration checks against the Redis mock to verify `scan` path and against a local Redis instance to verify `clear` and deduping behavior, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c6819534832c80e3a3d3f38ff3fe)