### PR TITLE
fix: minimize Redis session payload

### DIFF
--- a/server/global.d.ts
+++ b/server/global.d.ts
@@ -3,28 +3,34 @@
  */
 declare namespace Express {
   /**
+   * Subscription shape stored in the session. Kept whole for tenant routing
+   * (`subscription.db`) and per-request settings access.
+   *
    * @internal
    */
   interface UserSubscription {
     id: string
     name: string
-    settings: any
+    db?: string
+    settings?: Record<string, unknown>
   }
 
   /**
+   * Minimal user shape written to the Redis-backed session store.
+   * Only fields actually consumed during request handling are included.
+   * Profile fields (givenName, surname, jobTitle, mobilePhone,
+   * preferredLanguage, displayName) are intentionally excluded - they
+   * are never read from `request.user` at runtime.
+   *
    * @internal
    */
   interface User {
     id?: string
-    displayName?: string
-    givenName?: string
-    jobTitle?: string
     mail?: string
-    mobilePhone?: string
-    preferredLanguage?: string
-    role?: any
-    surname?: string
+    provider?: string
+    role?: { name?: string; permissions?: string[] }
     subscription?: UserSubscription
-    tokenParams?: any
+    configuration?: string | Record<string, unknown>
+    tokenParams?: Record<string, unknown>
   }
 }

--- a/server/middleware/passport/index.test.ts
+++ b/server/middleware/passport/index.test.ts
@@ -1,0 +1,119 @@
+/// <reference path="../../global.d.ts" />
+import test from 'ava'
+import { pickSessionFields } from './index'
+
+// --- pickSessionFields ---
+
+test('pickSessionFields: keeps id, mail, provider', (t) => {
+  const result = pickSessionFields({
+    id: 'u1',
+    mail: 'user@example.com',
+    provider: 'microsoft'
+  })
+  t.is(result.id, 'u1')
+  t.is(result.mail, 'user@example.com')
+  t.is(result.provider, 'microsoft')
+})
+
+test('pickSessionFields: keeps role with name and permissions', (t) => {
+  const role = { name: 'Owner', permissions: ['READ', 'WRITE'] }
+  const result = pickSessionFields({ role })
+  t.deepEqual(result.role, role)
+})
+
+test('pickSessionFields: keeps subscription for tenant routing', (t) => {
+  const subscription = { id: 'sub1', name: 'Acme', db: 'acme_db', settings: {} }
+  const result = pickSessionFields({ subscription })
+  t.deepEqual(result.subscription, subscription)
+})
+
+test('pickSessionFields: keeps configuration', (t) => {
+  const result = pickSessionFields({ configuration: 'some-config' })
+  t.is(result.configuration, 'some-config')
+})
+
+test('pickSessionFields: keeps tokenParams for OAuth refresh', (t) => {
+  const tokenParams = { access_token: 'tok', refresh_token: 'rtok', expires_in: 3600 }
+  const result = pickSessionFields({ tokenParams })
+  t.deepEqual(result.tokenParams, tokenParams)
+})
+
+test('pickSessionFields: drops givenName', (t) => {
+  const result = pickSessionFields({ givenName: 'Alice', id: 'u1' }) as any
+  t.is(result.givenName, undefined)
+})
+
+test('pickSessionFields: drops surname', (t) => {
+  const result = pickSessionFields({ surname: 'Smith', id: 'u1' }) as any
+  t.is(result.surname, undefined)
+})
+
+test('pickSessionFields: drops jobTitle', (t) => {
+  const result = pickSessionFields({ jobTitle: 'Engineer', id: 'u1' }) as any
+  t.is(result.jobTitle, undefined)
+})
+
+test('pickSessionFields: drops mobilePhone', (t) => {
+  const result = pickSessionFields({ mobilePhone: '+47 123', id: 'u1' }) as any
+  t.is(result.mobilePhone, undefined)
+})
+
+test('pickSessionFields: drops preferredLanguage', (t) => {
+  const result = pickSessionFields({ preferredLanguage: 'en-GB', id: 'u1' }) as any
+  t.is(result.preferredLanguage, undefined)
+})
+
+test('pickSessionFields: drops displayName', (t) => {
+  const result = pickSessionFields({ displayName: 'Alice Smith', id: 'u1' }) as any
+  t.is(result.displayName, undefined)
+})
+
+test('pickSessionFields: drops arbitrary extra fields', (t) => {
+  const result = pickSessionFields({
+    id: 'u1',
+    secretField: 'should-not-be-in-session',
+    anotherExtra: 42
+  }) as any
+  t.is(result.secretField, undefined)
+  t.is(result.anotherExtra, undefined)
+})
+
+test('pickSessionFields: handles empty input', (t) => {
+  const result = pickSessionFields({})
+  t.is(result.id, undefined)
+  t.is(result.mail, undefined)
+  t.is(result.provider, undefined)
+  t.is(result.role, undefined)
+  t.is(result.subscription, undefined)
+  t.is(result.configuration, undefined)
+  t.is(result.tokenParams, undefined)
+})
+
+test('pickSessionFields: output has exactly 7 keys when all provided', (t) => {
+  const result = pickSessionFields({
+    id: 'u1',
+    mail: 'user@example.com',
+    provider: 'microsoft',
+    role: { name: 'User' },
+    subscription: { id: 's1', name: 'Acme' },
+    configuration: {},
+    tokenParams: {},
+    // extras that should be dropped
+    givenName: 'Alice',
+    surname: 'Smith',
+    jobTitle: 'Engineer'
+  })
+  const keys = Object.keys(result).filter((k) => result[k as keyof typeof result] !== undefined)
+  t.is(keys.length, 7)
+})
+
+test('pickSessionFields: google provider is preserved', (t) => {
+  const result = pickSessionFields({
+    id: 'google-id',
+    mail: 'user@gmail.com',
+    provider: 'google',
+    tokenParams: { access_token: 'gtok', refresh_token: 'grtok' }
+  })
+  t.is(result.provider, 'google')
+  t.deepEqual(result.tokenParams, { access_token: 'gtok', refresh_token: 'grtok' })
+})

--- a/server/middleware/passport/index.ts
+++ b/server/middleware/passport/index.ts
@@ -4,6 +4,35 @@ import { googleStrategy } from './google'
 import { azureAdStrategy } from './microsoft'
 
 /**
+ * Trim the full user object down to the minimal set of fields that are
+ * actually read from `request.user` during request handling. This is the
+ * shape that gets written to the Redis-backed session store.
+ *
+ * Fields intentionally excluded (not read from `request.user`):
+ * - givenName, surname, jobTitle, mobilePhone, preferredLanguage (profile-only)
+ * - displayName (only used on Graph user objects, not session)
+ *
+ * @param user - Full user object from passport verify callback
+ * @returns Minimal session-safe user shape
+ */
+export function pickSessionFields(user: Record<string, unknown>): Express.User {
+  return {
+    id: user.id as string | undefined,
+    mail: user.mail as string | undefined,
+    provider: user.provider as string | undefined,
+    role: user.role as { name?: string; permissions?: string[] } | undefined,
+    subscription: user.subscription as
+      | { id: string; name: string; db?: string; settings?: Record<string, unknown> }
+      | undefined,
+    configuration: user.configuration as
+      | string
+      | Record<string, unknown>
+      | undefined,
+    tokenParams: user.tokenParams as Record<string, unknown> | undefined
+  }
+}
+
+/**
  * Setup passport to be used for authentication
  *
  * @param mcl - Mongo client
@@ -19,9 +48,14 @@ export const passportMiddleware = (mcl: MongoClient) => {
    * Each subsequent request will not contain credentials, but rather the
    * unique cookie that identifies the session. In order to support login sessions,
    * Passport will serialize and deserialize user instances to and from the session.
+   *
+   * pickSessionFields trims the user object to a minimal shape before writing
+   * to the Redis-backed session store, reducing payload size.
    */
-  passport.serializeUser((user, done) => done(null, user))
-  passport.deserializeUser((user, done) => done(null, user))
+  passport.serializeUser((user: any, done) => {
+    done(null, pickSessionFields(user))
+  })
+  passport.deserializeUser((user, done) => done(null, user as Express.User))
 
   passport.use(azureAdStrategy(mcl))
   passport.use(googleStrategy(mcl))

--- a/server/middleware/passport/microsoft/synchronizeUserProfile.ts
+++ b/server/middleware/passport/microsoft/synchronizeUserProfile.ts
@@ -67,7 +67,7 @@ export async function synchronizeUserProfile(
     user.id
   )
   try {
-    const msGraphSvc = new MSGraphService(new MSOAuthService({ user }))
+    const msGraphSvc = new MSGraphService(new MSOAuthService({ user } as any))
     const [data, userPhoto] = await Promise.all([
       msGraphSvc.getCurrentUser(properties),
       msGraphSvc.getUserPhoto('48x48')


### PR DESCRIPTION
## Summary
- Trim passport session payload via `pickSessionFields` before serialization to Redis
- Drop unused `Express.User` fields; tighten types on `role`, `subscription`, `tokenParams`
- Preserve OAuth token refresh flow (lighter path; deeper split deferred to upcoming dependency upgrade)

## Test plan
- [ ] `npm run lint` clean
- [ ] `npm test` green for passport test
- [ ] Sign in with Microsoft + Google in local Docker; confirm session works across navigations
- [ ] Force a token refresh via `msoauth.getAccessToken` and confirm it still works
- [ ] `updateSubscription` mutation still reflects new settings on the next request
- [ ] Inspect Redis session blob - confirm no `givenName/surname/jobTitle/mobilePhone/preferredLanguage`

Plan: `.plans/session-payload-minimization.md`
Addresses QA P2 from `.tmp/QA_2026-03-24/server_review.md`.