### PR TITLE
test: add auth boundary and URL state regression tests

### DIFF
--- a/client/utils/getUrlState.test.ts
+++ b/client/utils/getUrlState.test.ts
@@ -1,0 +1,110 @@
+import test from 'ava'
+
+// getUrlState uses window.atob and document.location (hash) / window.location.href (search).
+// We set up minimal globals before importing so the module resolves them at call time.
+
+function b64(str: string) {
+  return Buffer.from(str).toString('base64')
+}
+
+function setupHashWindow(hash: string) {
+  ;(global as any).document = { location: { hash } }
+  ;(global as any).window = {
+    atob: (s: string) => Buffer.from(s, 'base64').toString('utf-8'),
+    location: { href: 'http://localhost/' }
+  }
+}
+
+function setupSearchWindow(search: string) {
+  ;(global as any).document = { location: { hash: '' } }
+  ;(global as any).window = {
+    atob: (s: string) => Buffer.from(s, 'base64').toString('utf-8'),
+    location: { href: `http://localhost/${search}` }
+  }
+}
+
+// Import lazily so globals are set before first call
+function getUrlState<T = any>(
+  key: string,
+  location: 'hash' | 'search',
+  obj = false
+): T {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { getUrlState: fn } = require('./getUrlState')
+  return fn(key, location, obj)
+}
+
+// --- valid round-trip ---
+
+test('getUrlState: valid base64 JSON round-trips via hash', (t) => {
+  const payload = { week: 42, year: 2026 }
+  setupHashWindow(`#state=${b64(JSON.stringify(payload))}`)
+  const result = getUrlState('state', 'hash', true)
+  t.deepEqual(result, payload)
+})
+
+test('getUrlState: valid base64 JSON round-trips via search', (t) => {
+  const payload = { tab: 'custom' }
+  setupSearchWindow(`?filter=${b64(JSON.stringify(payload))}`)
+  const result = getUrlState('filter', 'search', true)
+  t.deepEqual(result, payload)
+})
+
+// --- crash guard: non-base64 input ---
+
+test('getUrlState: non-base64 garbage returns fallback ({}) without throwing', (t) => {
+  setupHashWindow('#state=!!!not-base64!!!')
+  t.notThrows(() => {
+    const result = getUrlState('state', 'hash', true)
+    t.deepEqual(result, {})
+  })
+})
+
+// --- crash guard: base64 of non-JSON ---
+
+test('getUrlState: base64 of plain text returns fallback ({}) without throwing', (t) => {
+  setupHashWindow(`#state=${b64('this is not json')}`)
+  t.notThrows(() => {
+    const result = getUrlState('state', 'hash', true)
+    t.deepEqual(result, {})
+  })
+})
+
+// --- shape mismatch: parsing succeeds, shape is caller's responsibility ---
+
+test('getUrlState: base64 JSON with unexpected shape returns decoded value', (t) => {
+  const payload = { unexpected: true, extra: [1, 2, 3] }
+  setupHashWindow(`#state=${b64(JSON.stringify(payload))}`)
+  const result = getUrlState<any>('state', 'hash', true)
+  // parsing succeeds; shape validation is the caller's job
+  t.deepEqual(result, payload)
+})
+
+// --- undefined / missing key ---
+
+test('getUrlState: missing key in hash returns empty object when obj=true', (t) => {
+  setupHashWindow('#other=foo')
+  const result = getUrlState('state', 'hash', true)
+  t.deepEqual(result, {})
+})
+
+test('getUrlState: missing key in search returns empty object when obj=true', (t) => {
+  setupSearchWindow('?other=foo')
+  const result = getUrlState('state', 'search', true)
+  t.deepEqual(result, {})
+})
+
+// --- obj=false (raw string) path ---
+
+test('getUrlState: returns raw string value from hash when obj=false', (t) => {
+  setupHashWindow('#tab=overview')
+  const result = getUrlState<string>('tab', 'hash', false)
+  t.is(result, 'overview')
+})
+
+test('getUrlState: returns null-like for missing key in search when obj=false', (t) => {
+  setupSearchWindow('?other=foo')
+  const result = getUrlState<string | undefined>('missing', 'search', false)
+  // URL.searchParams.get returns null for missing keys; the function returns it as-is
+  t.falsy(result)
+})

--- a/server/graphql/authChecker.test.ts
+++ b/server/graphql/authChecker.test.ts
@@ -1,0 +1,129 @@
+import 'reflect-metadata'
+import test from 'ava'
+import { GraphQLError } from 'graphql'
+import { authChecker as _authChecker } from './authChecker'
+import { PermissionScope } from '../../shared/config/security/types'
+
+// AuthChecker is a union of function | class, which confuses strict TS.
+// Cast to a plain callable so tests are readable without transpile-only.
+const authChecker = _authChecker as (
+  resolverData: any,
+  roles: any[]
+) => boolean | Promise<boolean>
+
+// Minimal ResolverData shape - authChecker only destructures `context`
+function makeResolverData(permissions?: string[], userId?: string) {
+  return {
+    context: { permissions, userId },
+    root: {},
+    args: {},
+    info: {} as any
+  } as any
+}
+
+// --- bare @Authorized() (no options) ---
+
+test('authChecker: anonymous request (no permissions) is rejected', (t) => {
+  const err = t.throws(
+    () => authChecker(makeResolverData(undefined), [undefined]),
+    { instanceOf: GraphQLError }
+  )
+  t.is((err as GraphQLError).extensions?.code, 'UNAUTHENTICATED')
+})
+
+test('authChecker: empty-permissions array is rejected (bare @Authorized)', (t) => {
+  const err = t.throws(
+    () => authChecker(makeResolverData([]), [undefined]),
+    { instanceOf: GraphQLError }
+  )
+  t.is((err as GraphQLError).extensions?.code, 'UNAUTHENTICATED')
+})
+
+// --- scoped @Authorized({ scope: X }) ---
+
+test('authChecker: empty-permissions array is rejected on scoped @Authorized', (t) => {
+  const err = t.throws(
+    () =>
+      authChecker(makeResolverData([]), [
+        { scope: PermissionScope.ACCESS_TIMESHEET }
+      ]),
+    { instanceOf: GraphQLError }
+  )
+  t.is((err as GraphQLError).extensions?.code, 'FORBIDDEN')
+})
+
+test('authChecker: user with matching scope is accepted', (t) => {
+  const result = authChecker(
+    makeResolverData([PermissionScope.ACCESS_TIMESHEET]),
+    [{ scope: PermissionScope.ACCESS_TIMESHEET }]
+  )
+  t.true(result)
+})
+
+test('authChecker: user with non-matching scope is rejected', (t) => {
+  const err = t.throws(
+    () =>
+      authChecker(makeResolverData([PermissionScope.ACCESS_CUSTOMERS]), [
+        { scope: PermissionScope.ACCESS_TIMESHEET }
+      ]),
+    { instanceOf: GraphQLError }
+  )
+  t.is((err as GraphQLError).extensions?.code, 'FORBIDDEN')
+})
+
+// --- requiresUserContext ---
+
+test('authChecker: requiresUserContext rejected when no userId', (t) => {
+  const err = t.throws(
+    () =>
+      authChecker(
+        makeResolverData([PermissionScope.ACCESS_TIMESHEET], undefined),
+        [{ requiresUserContext: true }]
+      ),
+    { instanceOf: GraphQLError }
+  )
+  t.is((err as GraphQLError).extensions?.code, 'UNAUTHENTICATED')
+})
+
+test('authChecker: requiresUserContext passes when userId is present', (t) => {
+  const result = authChecker(
+    makeResolverData([PermissionScope.ACCESS_TIMESHEET], 'user-123'),
+    [{ requiresUserContext: true }]
+  )
+  t.true(result)
+})
+
+// --- API-token path parity ---
+// An API token with empty permissions behaves the same as a session with [].
+// The token source is irrelevant to authChecker - only context.permissions matters.
+
+test('authChecker: API token with empty permissions rejected on bare @Authorized', (t) => {
+  // Simulate a context built from token auth with no permissions granted
+  const context = { permissions: [], tokenSource: 'api' as const }
+  const err = t.throws(
+    () => authChecker({ context } as any, [undefined]),
+    { instanceOf: GraphQLError }
+  )
+  t.is((err as GraphQLError).extensions?.code, 'UNAUTHENTICATED')
+})
+
+test('authChecker: API token with matching scope is accepted', (t) => {
+  const context = {
+    permissions: [PermissionScope.ACCESS_REPORTS],
+    tokenSource: 'api' as const
+  }
+  const result = authChecker({ context } as any, [
+    { scope: PermissionScope.ACCESS_REPORTS }
+  ])
+  t.true(result)
+})
+
+// --- bare @Authorized() with valid permissions ---
+
+test('authChecker: user with non-empty permissions passes bare @Authorized', (t) => {
+  const result = authChecker(
+    makeResolverData([PermissionScope.ACCESS_TIMESHEET]),
+    [undefined]
+  )
+  t.true(result)
+})


### PR DESCRIPTION
## Summary
- Add focused AVA tests for `authChecker` covering anonymous, empty-permissions (bare + scoped), scope-match, and API-token parity
- Add AVA tests for `getUrlState` covering base64 garbage, non-JSON payloads, and shape mismatches

No runtime changes. Regression coverage for QA fixes landed in 932e09082 (URL crash guard) and f72ff5ef5 (auth hardening).

Intentionally out of scope (covered by sibling PRs):
- Session-payload `pickSessionFields` test (in session-payload-minimization PR)
- Tenant subscription refresh test (in tenant-subscription-refresh PR)
- Holiday date normalization test (in holiday-date-normalization PR)
- Apollo provider staleness tests (no React Testing Library in the project; deferred)
- Docker bootstrap shell tests (no shell test harness; deferred)

## Test plan
- [ ] `npm run lint` clean
- [ ] `npm test` green for the two new files
- [ ] New tests fail when the underlying fix is reverted (confirms they cover the behavior)

Plan: `.plans/qa-regression-tests.md`