### PR TITLE
docs: finalize 0.21.0 release notes and fix stale README entries

### DIFF
--- a/.changelog/0.21.0.md
+++ b/.changelog/0.21.0.md
@@ -1,4 +1,4 @@
-## 0.21.0 - 23.04.2026
+## 0.21.0 - 24.04.2026
 
 ### Highlights
 
@@ -7,6 +7,7 @@
 - 📊 **Reports UX Overhaul**: ViewColumnsPanel gains Reset/Save/Cancel, multi-project filter for custom queries, compact date headers in Summary, and a fresh Excel export that reads the live column state (#1372, #1373)
 - 📱 **Mobile Summary Visibility**: Fixed invisible hours in the Timesheet Summary card layout on mobile (#1364)
 - 🧱 **List Column Sizing Rewrite**: Dropped the localStorage persistence layer in favour of content-sampled initial widths with admin-set `minWidth`/`maxWidth`/`idealWidth` as the single source of truth (#1375)
+- ⚡ **Cache and Session Hardening**: SCAN-based cache invalidation, request coalescing, trimmed Redis session payload, and per-request subscription metadata refresh (#1374, #1377, #1378)
 
 ### Added
 
@@ -65,6 +66,25 @@
   - Disabled Apollo variable reporting in `setupGraphQL` and tightened related types
 - **Shared layer decoupled from server** (`f72ff5ef5`)
   - Introduced `IHolidayObject` interface in `shared/types/`; removed server imports from `shared/`
+- **Holiday date normalization** (#1376)
+  - `getHolidayHoursInPeriod` and sibling helpers in `shared/utils/holidayUtils.ts` now route date inputs through `parseHolidayDate` / `toISODateString` instead of raw `$dayjs()`
+  - Handles ISO datetime strings, `Date` objects, and leap-year edge cases consistently
+- **Subscription metadata staleness** (#1377)
+  - `RequestContext.create` now refetches the subscription document from the main database on each request for session-authenticated callers
+  - Falls back to the session copy on lookup miss or Mongo error to avoid 500s during outages
+  - Closes the last staleness gap for tenant settings and feature flags (permissions were already refreshed per-request)
+- **Redis session payload size** (#1378)
+  - New `pickSessionFields` trims `Express.User` to `id`, `mail`, `provider`, `role.name`, `subscription`, `configuration`, and `tokenParams` before `passport.serializeUser` writes it to Redis
+  - `global.d.ts` drops unused fields (`givenName`, `jobTitle`, `mobilePhone`, `preferredLanguage`, `surname`) and tightens `tokenParams` / `role` / `subscription` types
+
+### Performance
+
+- **Cache semantics hardened and Redis TTLs tuned** (#1374)
+  - `CacheService.clear` swaps `KEYS` for a cursor-based `SCAN` loop (`COUNT 200`) so cache invalidation no longer blocks Redis on large keyspaces
+  - `usingCache` coalesces concurrent requests for the same key via an in-flight promise map, avoiding thundering herds when the cache is cold
+  - Distinguishes cache miss (`reply == null`) from parse error explicitly
+  - TTLs tuned: `getProjects` 30s -> 180s, calendar events 20s -> 60s, customer lookups now use `sha256` hashing to keep cache keys stable under query variation
+  - Added `scan` stub to the no-op Redis fallback so local dev without Redis keeps working
 
 ### Infrastructure
 
@@ -93,8 +113,20 @@
 - **Personal Access Tokens** design spec and implementation plan checked in under planning docs (#1370 follow-ups)
 - **`/did` skill and did-cli** design spec and implementation plan checked in for the upcoming Claude Code integration
 
+### Tests
+
+- **Auth boundary and URL state regression coverage** (#1379)
+  - `authChecker.test.ts`: anonymous request rejection, empty-permissions rejection (bare and scoped), scope-match acceptance, API-token path parity
+  - `getUrlState.test.ts`: fallback on non-base64, non-JSON, unexpected shapes, and empty input
+- **Redis session serialization** (#1378)
+  - Focused test for `pickSessionFields` to lock the trimmed session shape
+- **RequestContext subscription refresh** (#1377)
+  - Covers the fresh / miss / Mongo-error paths for per-request subscription lookup
+- **Holiday date parsing** (#1376)
+  - Regression tests for ISO datetime strings, `Date` objects, and leap-year boundaries
+
 ### Verification
 
 - `npm run lint` passes
 - `npm run build:server` passes
-- `npm test` passes (2565 tests, including new `estimateColumnWidth` unit tests)
+- `npm test` passes (including new auth boundary, URL state, session serialization, RequestContext, and holiday date tests)

--- a/.readme/1-roadmap.md
+++ b/.readme/1-roadmap.md
@@ -22,3 +22,4 @@
 | [☁️&nbsp;18 -  &nbsp;Argon](https://github.com/Puzzlepart/did/milestone/18) | 08.01.2026 | [![version](https://img.shields.io/badge/version-0.18.0-green.svg)](https://semver.org) |
 | [🧴&nbsp;19 -  &nbsp;Potassium](https://github.com/Puzzlepart/did/milestone/18) | 19.01.2026 | [![version](https://img.shields.io/badge/version-0.19.0-yellow.svg)](https://semver.org) |
 | [🥛&nbsp;20 -  &nbsp;Calcium](https://github.com/Puzzlepart/did/milestone/18) | 11.03.2026 | [![version](https://img.shields.io/badge/version-0.20.0-red.svg)](https://semver.org) |
+| [⚾&nbsp;21 -  &nbsp;Scandium](https://github.com/Puzzlepart/did/milestone/18) | 24.04.2026 | [![version](https://img.shields.io/badge/version-0.21.0-green.svg)](https://semver.org) |

--- a/.readme/4-contributing.md
+++ b/.readme/4-contributing.md
@@ -1,6 +1,6 @@
 ## Contributing
 
-_Contributions are very velcome! Here's some guidance to get started!_ :heart:
+_Contributions are very welcome! Here's some guidance to get started!_ :heart:
 
 
 ### Getting started
@@ -8,7 +8,7 @@ _Contributions are very velcome! Here's some guidance to get started!_ :heart:
 1. Check out the `dev` branch
 2. Run `npm install`
 3. Run `npm run-script create-env` to create your own `.env` file for local testing
-4. Set neccessary parameters in your new `.env` file (see `Set up .env` below)
+4. Set necessary parameters in your new `.env` file (see `Set up .env` below)
 5. Install the [Azure App Service extension for vscode](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureappservice)
 6. Install the [ESLint extension for vscode](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 7. Install the [i18n Ally extension for vscode](https://marketplace.visualstudio.com/items?itemName=Lokalise.i18n-ally)
@@ -22,7 +22,7 @@ The following permissions are required by Azure App Registration:
 
 #### Set up environment
 
-You've copied `.env.sample` into `.env`, anually or using `npm run-script create-env`.
+You've copied `.env.sample` into `.env`, manually or using `npm run-script create-env`.
 
 Now you need to set the required environment variables from this table:
 
@@ -46,7 +46,7 @@ Now you need to set the required environment variables from this table:
 | `APOLLO_GRAPH_VARIANT` | Graph variant for reporting to [Apollo Studio](https://studio.apollographql.com/org/puzzlepart/graphs). See [this article](https://www.apollographql.com/docs/apollo-server/monitoring/metrics/) | **Yes**  |
 | `MONGO_DB_CONNECTION_STRING` | Connection string for MongoDB                                | **Yes**  |
 | `MONGO_DB_DB_NAME` | Database name for MongoDB                                    | **Yes**  |
-| `API_TOKEN_SECRET` | Secret to generate API tokens                                | **Yes**  |
+| `API_TOKEN_SECRET` | Secret used to sign API tokens and personal access tokens (PATs) | **Yes**  |
 | `DEBUG`                         | To debug the Node backend. E.g. `app*` to see all logs from app. See [debug](https://www.npmjs.com/package/debug). | No       |
 | `LAUNCH_BROWSER`      | Set to `1` if you want to automatically open did in the browser when running `watch` task. | No       |
 
@@ -89,7 +89,7 @@ Now you need to set the required environment variables from this table:
 
 **NB: did should be developed with Node 22.14.0 (LTS).**
 
-_It's recommended to use `nvm`. We have a `.nvrc` with node version set to 18.18.0._
+_It's recommended to use `nvm`. We have a `.nvmrc` with node version set to 22.14.0._
 
 ### Authentication
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## ➤ Table of Contents
 
 * [➤ Changelog](#-changelog)
-	* [➤ 0.21.0 - 23.04.2026](#-0210---23042026)
+	* [➤ 0.21.0 - 24.04.2026](#-0210---24042026)
 		* [Highlights](#highlights)
 		* [Added](#added)
 		* [Changed](#changed)
 		* [Fixed](#fixed)
+		* [Performance](#performance)
 		* [Infrastructure](#infrastructure)
 		* [Documentation](#documentation)
+		* [Tests](#tests)
 		* [Verification](#verification)
 	* [➤ 0.20.0 - 16.03.2026](#-0200---16032026)
 		* [Highlights](#highlights-1)
@@ -179,9 +181,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 </details>
 
 
-[](#0210---23042026)
+[](#0210---24042026)
 
-## ➤ 0.21.0 - 23.04.2026
+## ➤ 0.21.0 - 24.04.2026
 
 ### Highlights
 
@@ -190,6 +192,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 📊 **Reports UX Overhaul**: ViewColumnsPanel gains Reset/Save/Cancel, multi-project filter for custom queries, compact date headers in Summary, and a fresh Excel export that reads the live column state (#1372, #1373)
 - 📱 **Mobile Summary Visibility**: Fixed invisible hours in the Timesheet Summary card layout on mobile (#1364)
 - 🧱 **List Column Sizing Rewrite**: Dropped the localStorage persistence layer in favour of content-sampled initial widths with admin-set `minWidth`/`maxWidth`/`idealWidth` as the single source of truth (#1375)
+- ⚡ **Cache and Session Hardening**: SCAN-based cache invalidation, request coalescing, trimmed Redis session payload, and per-request subscription metadata refresh (#1374, #1377, #1378)
 
 ### Added
 
@@ -248,6 +251,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Disabled Apollo variable reporting in `setupGraphQL` and tightened related types
 - **Shared layer decoupled from server** (`f72ff5ef5`)
   - Introduced `IHolidayObject` interface in `shared/types/`; removed server imports from `shared/`
+- **Holiday date normalization** (#1376)
+  - `getHolidayHoursInPeriod` and sibling helpers in `shared/utils/holidayUtils.ts` now route date inputs through `parseHolidayDate` / `toISODateString` instead of raw `$dayjs()`
+  - Handles ISO datetime strings, `Date` objects, and leap-year edge cases consistently
+- **Subscription metadata staleness** (#1377)
+  - `RequestContext.create` now refetches the subscription document from the main database on each request for session-authenticated callers
+  - Falls back to the session copy on lookup miss or Mongo error to avoid 500s during outages
+  - Closes the last staleness gap for tenant settings and feature flags (permissions were already refreshed per-request)
+- **Redis session payload size** (#1378)
+  - New `pickSessionFields` trims `Express.User` to `id`, `mail`, `provider`, `role.name`, `subscription`, `configuration`, and `tokenParams` before `passport.serializeUser` writes it to Redis
+  - `global.d.ts` drops unused fields (`givenName`, `jobTitle`, `mobilePhone`, `preferredLanguage`, `surname`) and tightens `tokenParams` / `role` / `subscription` types
+
+### Performance
+
+- **Cache semantics hardened and Redis TTLs tuned** (#1374)
+  - `CacheService.clear` swaps `KEYS` for a cursor-based `SCAN` loop (`COUNT 200`) so cache invalidation no longer blocks Redis on large keyspaces
+  - `usingCache` coalesces concurrent requests for the same key via an in-flight promise map, avoiding thundering herds when the cache is cold
+  - Distinguishes cache miss (`reply == null`) from parse error explicitly
+  - TTLs tuned: `getProjects` 30s -> 180s, calendar events 20s -> 60s, customer lookups now use `sha256` hashing to keep cache keys stable under query variation
+  - Added `scan` stub to the no-op Redis fallback so local dev without Redis keeps working
 
 ### Infrastructure
 
@@ -276,11 +298,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Personal Access Tokens** design spec and implementation plan checked in under planning docs (#1370 follow-ups)
 - **`/did` skill and did-cli** design spec and implementation plan checked in for the upcoming Claude Code integration
 
+### Tests
+
+- **Auth boundary and URL state regression coverage** (#1379)
+  - `authChecker.test.ts`: anonymous request rejection, empty-permissions rejection (bare and scoped), scope-match acceptance, API-token path parity
+  - `getUrlState.test.ts`: fallback on non-base64, non-JSON, unexpected shapes, and empty input
+- **Redis session serialization** (#1378)
+  - Focused test for `pickSessionFields` to lock the trimmed session shape
+- **RequestContext subscription refresh** (#1377)
+  - Covers the fresh / miss / Mongo-error paths for per-request subscription lookup
+- **Holiday date parsing** (#1376)
+  - Regression tests for ISO datetime strings, `Date` objects, and leap-year boundaries
+
 ### Verification
 
 - `npm run lint` passes
 - `npm run build:server` passes
-- `npm test` passes (2565 tests, including new `estimateColumnWidth` unit tests)
+- `npm test` passes (including new auth boundary, URL state, session serialization, RequestContext, and holiday date tests)
 
 
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@
 | [☁️&nbsp;18 -  &nbsp;Argon](https://github.com/Puzzlepart/did/milestone/18) | 08.01.2026 | [![version](https://img.shields.io/badge/version-0.18.0-green.svg)](https://semver.org) |
 | [🧴&nbsp;19 -  &nbsp;Potassium](https://github.com/Puzzlepart/did/milestone/18) | 19.01.2026 | [![version](https://img.shields.io/badge/version-0.19.0-yellow.svg)](https://semver.org) |
 | [🥛&nbsp;20 -  &nbsp;Calcium](https://github.com/Puzzlepart/did/milestone/18) | 11.03.2026 | [![version](https://img.shields.io/badge/version-0.20.0-red.svg)](https://semver.org) |
+| [⚾&nbsp;21 -  &nbsp;Scandium](https://github.com/Puzzlepart/did/milestone/18) | 24.04.2026 | [![version](https://img.shields.io/badge/version-0.21.0-green.svg)](https://semver.org) |
 
 
 [](#backlog)
@@ -100,7 +101,7 @@ Our backlog can be found [here](https://github.com/orgs/Puzzlepart/projects/7).
 
 ## ➤ Contributing
 
-_Contributions are very velcome! Here's some guidance to get started!_ :heart:
+_Contributions are very welcome! Here's some guidance to get started!_ :heart:
 
 
 ### Getting started
@@ -108,7 +109,7 @@ _Contributions are very velcome! Here's some guidance to get started!_ :heart:
 1. Check out the `dev` branch
 2. Run `npm install`
 3. Run `npm run-script create-env` to create your own `.env` file for local testing
-4. Set neccessary parameters in your new `.env` file (see `Set up .env` below)
+4. Set necessary parameters in your new `.env` file (see `Set up .env` below)
 5. Install the [Azure App Service extension for vscode](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureappservice)
 6. Install the [ESLint extension for vscode](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 7. Install the [i18n Ally extension for vscode](https://marketplace.visualstudio.com/items?itemName=Lokalise.i18n-ally)
@@ -122,7 +123,7 @@ The following permissions are required by Azure App Registration:
 
 #### Set up environment
 
-You've copied `.env.sample` into `.env`, anually or using `npm run-script create-env`.
+You've copied `.env.sample` into `.env`, manually or using `npm run-script create-env`.
 
 Now you need to set the required environment variables from this table:
 
@@ -146,7 +147,7 @@ Now you need to set the required environment variables from this table:
 | `APOLLO_GRAPH_VARIANT` | Graph variant for reporting to [Apollo Studio](https://studio.apollographql.com/org/puzzlepart/graphs). See [this article](https://www.apollographql.com/docs/apollo-server/monitoring/metrics/) | **Yes**  |
 | `MONGO_DB_CONNECTION_STRING` | Connection string for MongoDB                                | **Yes**  |
 | `MONGO_DB_DB_NAME` | Database name for MongoDB                                    | **Yes**  |
-| `API_TOKEN_SECRET` | Secret to generate API tokens                                | **Yes**  |
+| `API_TOKEN_SECRET` | Secret used to sign API tokens and personal access tokens (PATs) | **Yes**  |
 | `DEBUG`                         | To debug the Node backend. E.g. `app*` to see all logs from app. See [debug](https://www.npmjs.com/package/debug). | No       |
 | `LAUNCH_BROWSER`      | Set to `1` if you want to automatically open did in the browser when running `watch` task. | No       |
 
@@ -189,7 +190,7 @@ Now you need to set the required environment variables from this table:
 
 **NB: did should be developed with Node 22.14.0 (LTS).**
 
-_It's recommended to use `nvm`. We have a `.nvrc` with node version set to 18.18.0._
+_It's recommended to use `nvm`. We have a `.nvmrc` with node version set to 22.14.0._
 
 ### Authentication
 


### PR DESCRIPTION
## Summary

- Set 0.21.0 deployment date to **24.04.2026** and fill in the late-landing entries that had not been captured when the changelog was first drafted:
  - Cache semantics hardened and Redis TTLs tuned (#1374)
  - Holiday date normalization via `parseHolidayDate` (#1376)
  - Per-request subscription metadata refresh in `RequestContext` (#1377)
  - Minimized Redis session payload via `pickSessionFields` (#1378)
  - Auth boundary and URL state regression tests (#1379)
- Add the 21 - Scandium row to the roadmap with the 0.21.0 badge.
- Fix long-standing typos in `.readme/4-contributing.md`: `velcome` -> `welcome`, `neccessary` -> `necessary`, `anually` -> `manually`.
- Correct the Node version note: the file was pointing at a non-existent `.nvrc` with `18.18.0`; actual file is `.nvmrc` with `22.14.0`.
- Update `API_TOKEN_SECRET` description to reflect that it now also signs personal access tokens.
- Regenerate `README.md` and `CHANGELOG.md` to match the updated source files.

## Test plan

- [x] `.changelog/0.21.0.md` reflects every PR and direct commit merged since 0.20.0
- [x] Regenerated `README.md` and `CHANGELOG.md` are in sync with their `.readme/` / `.changelog/` sources
- [x] Roadmap row for 0.21.0 renders with the correct date and green badge
- [ ] CI green on dev branch after merge