### PR TITLE
fix: use checkMemberGroups for security group membership

### DIFF
--- a/server/services/msgraph/MSGraphService.test.ts
+++ b/server/services/msgraph/MSGraphService.test.ts
@@ -1,0 +1,103 @@
+import test from 'ava'
+import { MSGraphService } from './MSGraphService'
+
+/**
+ * Tests for `MSGraphService.isUserMemberOfSecurityGroup`.
+ *
+ * The Graph client is stubbed at the `_getClient` boundary so we can
+ * assert on the request path and method invoked on the fluent API.
+ */
+
+type ApiCall = {
+  path: string
+  method: 'get' | 'post'
+  body?: any
+}
+
+function createServiceWithStub(options: {
+  postResponse?: any
+  postError?: Error
+}) {
+  const calls: ApiCall[] = []
+
+  const api = (path: string) => ({
+    get: async () => {
+      calls.push({ path, method: 'get' })
+      return { value: [] }
+    },
+    post: async (body: any) => {
+      calls.push({ path, method: 'post', body })
+      if (options.postError) throw options.postError
+      return options.postResponse
+    }
+  })
+
+  const fakeClient = { api }
+
+  const service = new MSGraphService(
+    { getAccessToken: async () => ({ access_token: 'fake' }) } as any,
+    'fake-token',
+    {} as any
+  )
+  // Override the private client resolver to avoid real OAuth.
+  ;(service as any)._getClient = async () => fakeClient
+
+  return { service, calls }
+}
+
+test('isUserMemberOfSecurityGroup returns true when Graph reports membership', async (t) => {
+  const { service, calls } = createServiceWithStub({
+    postResponse: { value: ['group-1'] }
+  })
+
+  const result = await service.isUserMemberOfSecurityGroup(
+    'group-1',
+    'user@example.com'
+  )
+
+  t.true(result)
+  t.is(calls.length, 1)
+  t.is(calls[0].method, 'post')
+  t.is(calls[0].path, '/users/user%40example.com/checkMemberGroups')
+  t.deepEqual(calls[0].body, { groupIds: ['group-1'] })
+})
+
+test('isUserMemberOfSecurityGroup returns false when Graph reports no membership', async (t) => {
+  const { service } = createServiceWithStub({
+    postResponse: { value: [] }
+  })
+
+  const result = await service.isUserMemberOfSecurityGroup(
+    'group-1',
+    'user@example.com'
+  )
+
+  t.false(result)
+})
+
+test('isUserMemberOfSecurityGroup returns false when Graph throws', async (t) => {
+  const { service } = createServiceWithStub({
+    postError: new Error('Graph exploded')
+  })
+
+  const result = await service.isUserMemberOfSecurityGroup(
+    'group-1',
+    'user@example.com'
+  )
+
+  t.false(result)
+})
+
+test('isUserMemberOfSecurityGroup URL-encodes mail addresses with unsafe characters', async (t) => {
+  const { service, calls } = createServiceWithStub({
+    postResponse: { value: ['group-1'] }
+  })
+
+  const result = await service.isUserMemberOfSecurityGroup(
+    'group-1',
+    'user+tag@example.com'
+  )
+
+  t.true(result)
+  t.is(calls[0].path, '/users/user%2Btag%40example.com/checkMemberGroups')
+})

--- a/server/services/msgraph/MSGraphService.ts
+++ b/server/services/msgraph/MSGraphService.ts
@@ -10,6 +10,7 @@ import { environment } from '../../utils'
 import { CacheOptions, CacheScope, CacheService } from '../cache'
 import MSOAuthService, { MSAccessTokenOptions } from '../msoauth'
 import { MSGraphError, MSGraphOutlookCategory } from './types'
+const debug = require('debug')('services/msgraph')
 
 /**
  * Microsoft Graph service
@@ -390,11 +391,17 @@ export class MSGraphService {
   ): Promise<boolean> {
     try {
       const client = await this._getClient()
-      const response = await (client
-        .api(`/groups/${groupId}/members?$select=id,mail`)
-        .get() as Promise<{ value: any[] }>)
-      return response.value.some((member) => member.mail === mail)
-    } catch {
+      const response = (await client
+        .api(`/users/${encodeURIComponent(mail)}/checkMemberGroups`)
+        .post({ groupIds: [groupId] })) as { value: string[] }
+      return response.value?.includes(groupId) ?? false
+    } catch (error) {
+      debug(
+        '[isUserMemberOfSecurityGroup]',
+        'Graph check failed for',
+        mail,
+        error?.message
+      )
       return false
     }
   }


### PR DESCRIPTION
## Summary

- Replaces `MSGraphService.isUserMemberOfSecurityGroup` with a single `POST /users/{mail}/checkMemberGroups` call. The previous implementation fetched only the first page of `/groups/{id}/members` and scanned locally, silently denying legitimate members in groups larger than the default page size (~100).
- The new call is O(1) and transitive, so nested-group membership is handled correctly too.
- Adds a `debug()` log on catch so operational failures (permission/consent issues, transient Graph errors) are visible instead of returning `false` silently.
- Public signature and return contract are unchanged: `(groupId, mail) => Promise<boolean>`.

## Graph permission requirement

`checkMemberGroups` requires `User.Read.All` or `Directory.Read.All` application/delegated permission. `MICROSOFT_SCOPES` in `.env.sample` already includes `user.read.all`, so no scope change is required for standard deployments. If a tenant's app registration is missing that permission, the endpoint will 403 and the catch will log + return false (fail-closed, same as today). The added debug log makes this diagnosable.

## Files changed

- `server/services/msgraph/MSGraphService.ts` - new implementation + `debug` import
- `server/services/msgraph/MSGraphService.test.ts` - new, stubs the Graph client and covers member/non-member/error/url-encoding paths

## Test plan

- [x] `npm run lint` passes
- [ ] `npm test` - the four new `isUserMemberOfSecurityGroup` cases pass in isolation. Note: several pre-existing tests (`ReportService.test.ts`, `passport/index.test.ts`, `timesheet/extensions.test.ts`) fail compilation under ts-node with `TS2694: Namespace 'global.Express' has no exported member 'User'` on this worktree. This is unrelated to this change (reproduces on clean `origin/dev`) and appears to pre-date this PR; flagged here for awareness.
- [ ] Manual sign-in smoke test with a small security group - confirm existing member still signs in.
- [ ] Manual sign-in smoke test with a group that has >100 members - previously broken, should now succeed.

## Out of scope

- `checkSecurityGroupMembership.ts` caller shape (separate plan).
- Widening the signature to accept user IDs (callers only have `mail`).
- Caching (call is one-per-sign-in and fast).