### PR TITLE
fix: require INVITE_EXTERNAL_USERS for externalInvitations query

### DIFF
--- a/client/pages/Admin/Users/hooks/useUsersQuery.ts
+++ b/client/pages/Admin/Users/hooks/useUsersQuery.ts
@@ -1,5 +1,7 @@
 import { useQuery } from '@apollo/client'
+import { usePermissions } from 'hooks/user/usePermissions'
 import { Dispatch, useEffect } from 'react'
+import { PermissionScope } from 'security'
 import { DATA_UPDATED } from '../reducer/actions'
 import $users from './users.gql'
 import { AnyAction } from '@reduxjs/toolkit'
@@ -10,8 +12,11 @@ import { AnyAction } from '@reduxjs/toolkit'
  * @param dispatch - Redux dispatch function for `Users` component
  */
 export function useUsersQuery(dispatch: Dispatch<AnyAction>) {
+  const [, hasPermission] = usePermissions()
+  const includeInvitations = hasPermission(PermissionScope.INVITE_EXTERNAL_USERS)
   const query = useQuery($users, {
-    fetchPolicy: 'cache-and-network'
+    fetchPolicy: 'cache-and-network',
+    variables: { includeInvitations }
   })
 
   useEffect(() => dispatch(DATA_UPDATED({ query })), [query.loading])

--- a/client/pages/Admin/Users/hooks/users.gql
+++ b/client/pages/Admin/Users/hooks/users.gql
@@ -1,4 +1,4 @@
-query UsersAdmin {
+query UsersAdmin($includeInvitations: Boolean = false) {
   users {
     id
     displayName
@@ -38,9 +38,9 @@ query UsersAdmin {
     readOnly
     enabledForExternalUsers
   }
-  invitations: externalInvitations {
+  invitations: externalInvitations @include(if: $includeInvitations) {
     id
-    name  
+    name
     mail
     role
     invitedAt

--- a/server/graphql/resolvers/subscription/SubscriptionResolver.test.ts
+++ b/server/graphql/resolvers/subscription/SubscriptionResolver.test.ts
@@ -1,0 +1,60 @@
+import 'reflect-metadata'
+import test from 'ava'
+import { GraphQLError } from 'graphql'
+import { PermissionScope } from '../../../../shared/config/security/types'
+import { authChecker as _authChecker } from '../../authChecker'
+
+// The `externalInvitations` query exposes the tenant's pending external-user
+// invitations (names, emails, inviter). Read access must match the write
+// access that `inviteExternalUser` / `cancelExternalInvitation` require,
+// so the resolver is decorated with
+// `@Authorized<IAuthOptions>({ scope: PermissionScope.INVITE_EXTERNAL_USERS })`.
+//
+// The decorator is enforced by the shared `authChecker`. These tests exercise
+// the two branches via the checker with the exact options the resolver uses.
+
+// AuthChecker is a union of function | class, which confuses strict TS.
+// Cast to a plain callable so tests are readable without transpile-only.
+const authChecker = _authChecker as (
+  resolverData: any,
+  roles: any[]
+) => boolean | Promise<boolean>
+
+const externalInvitationsAuthOptions = {
+  scope: PermissionScope.INVITE_EXTERNAL_USERS
+}
+
+const makeResolverData = (permissions?: string[]) =>
+  ({
+    context: { permissions },
+    root: {},
+    args: {},
+    info: {} as any
+  }) as any
+
+test('externalInvitations: caller with INVITE_EXTERNAL_USERS is accepted', (t) => {
+  const result = authChecker(
+    makeResolverData([PermissionScope.INVITE_EXTERNAL_USERS]),
+    [externalInvitationsAuthOptions]
+  )
+  t.true(result)
+})
+
+test('externalInvitations: caller without INVITE_EXTERNAL_USERS is rejected with FORBIDDEN', (t) => {
+  const err = t.throws(
+    () =>
+      authChecker(makeResolverData([PermissionScope.ACCESS_ADMIN]), [
+        externalInvitationsAuthOptions
+      ]),
+    { instanceOf: GraphQLError }
+  )
+  t.is((err as GraphQLError).extensions?.code, 'FORBIDDEN')
+})
+
+test('externalInvitations: empty permissions rejected with FORBIDDEN', (t) => {
+  const err = t.throws(
+    () => authChecker(makeResolverData([]), [externalInvitationsAuthOptions]),
+    { instanceOf: GraphQLError }
+  )
+  t.is((err as GraphQLError).extensions?.code, 'FORBIDDEN')
+})

--- a/server/graphql/resolvers/subscription/SubscriptionResolver.ts
+++ b/server/graphql/resolvers/subscription/SubscriptionResolver.ts
@@ -141,6 +141,7 @@ export class SubscriptionResolver {
    *
    * @returns A promise that resolves to the external invitations.
    */
+  @Authorized<IAuthOptions>({ scope: PermissionScope.INVITE_EXTERNAL_USERS })
   @Query(() => [ExternalUserInvitation], {
     description: 'Get external invitations',
     nullable: true


### PR DESCRIPTION
## Summary

- Add `@Authorized<IAuthOptions>({ scope: PermissionScope.INVITE_EXTERNAL_USERS })` to the `externalInvitations` query so read access matches the gating already in place on `inviteExternalUser` and `cancelExternalInvitation`. Before this change, any authenticated tenant user could fetch the list of pending invitations (names, emails, inviter).
- The field is bundled inside the Admin Users `UsersAdmin` query, which ACCESS_ADMIN users open without necessarily holding INVITE_EXTERNAL_USERS. To avoid a FORBIDDEN on that shared query, guard the field with `@include(if: \$includeInvitations)` and derive the variable client-side via `usePermissions`.
- Add resolver tests covering the authorized / unauthorized / empty-permissions branches against the shared auth checker.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` passes for the new SubscriptionResolver tests (3 added); pre-existing unrelated TS2694/TS2339 failures in ReportService / extensions / passport index remain unchanged on this branch and on base
- [ ] Smoke: admin with INVITE_EXTERNAL_USERS sees pending invitations on Admin > Users
- [ ] Smoke: admin without INVITE_EXTERNAL_USERS opens Admin > Users with no error and no invitations list
- [ ] Smoke: non-admin user cannot call `externalInvitations` directly (receives FORBIDDEN)