### PR TITLE
fix: require auth on submitFeedback mutation

### DIFF
--- a/server/graphql/resolvers/user/UserResolver.test.ts
+++ b/server/graphql/resolvers/user/UserResolver.test.ts
@@ -1,0 +1,46 @@
+import 'reflect-metadata'
+import test from 'ava'
+import { GraphQLError } from 'graphql'
+import { authChecker as _authChecker } from '../../authChecker'
+
+// AuthChecker is a union of function | class, which confuses strict TS.
+// Cast to a plain callable so tests are readable without transpile-only.
+const authChecker = _authChecker as (
+  resolverData: any,
+  roles: any[]
+) => boolean | Promise<boolean>
+
+// Mirrors the @Authorized<IAuthOptions>({ requiresUserContext: true })
+// decorator applied to UserResolver.submitFeedback. If this literal drifts
+// from the decorator, the guard intent drifts too - keep them in sync.
+const feedbackAuthOptions = [{ requiresUserContext: true }]
+
+function makeResolverData(userId?: string) {
+  return {
+    context: { permissions: [], userId },
+    root: {},
+    args: {},
+    info: {} as any
+  } as any
+}
+
+test('submitFeedback auth: rejects unauthenticated caller with UNAUTHENTICATED', (t) => {
+  const err = t.throws(
+    () => authChecker(makeResolverData(undefined), feedbackAuthOptions),
+    { instanceOf: GraphQLError }
+  )
+  t.is((err as GraphQLError).extensions?.code, 'UNAUTHENTICATED')
+})
+
+test('submitFeedback auth: rejects caller with empty permissions and no userId', (t) => {
+  const err = t.throws(
+    () => authChecker(makeResolverData(undefined), feedbackAuthOptions),
+    { instanceOf: GraphQLError }
+  )
+  t.is((err as GraphQLError).extensions?.code, 'UNAUTHENTICATED')
+})
+
+test('submitFeedback auth: passes when userId is present on context', (t) => {
+  const result = authChecker(makeResolverData('user-123'), feedbackAuthOptions)
+  t.true(result)
+})

--- a/server/graphql/resolvers/user/UserResolver.ts
+++ b/server/graphql/resolvers/user/UserResolver.ts
@@ -418,6 +418,7 @@ export class UserResolver {
    *
    * @param feedback - Feedback model
    */
+  @Authorized<IAuthOptions>({ requiresUserContext: true })
   @Mutation(() => UserFeedbackResult, { description: 'Submit feedback' })
   public async submitFeedback(
     @Arg('feedback') feedback: UserFeedback


### PR DESCRIPTION
## Summary
- `submitFeedback` on `UserResolver` had no `@Authorized` guard, and `/graphql` is a public Express route, so unauthenticated callers could invoke the mutation and spam GitHub issues on the feedback repo using our app-configured credentials.
- Add `@Authorized<IAuthOptions>({ requiresUserContext: true })` - matching the pattern already used on `updateUserConfiguration` and `updateUserTimebank` - so anonymous requests are rejected with `UNAUTHENTICATED` at the TypeGraphQL layer before any `GitHubService.createIssue` call.
- `IAuthOptions` was already imported, so no new imports are needed.
- Add `server/graphql/resolvers/user/UserResolver.test.ts` covering the feedback auth option shape against `authChecker`: unauthenticated rejected, authenticated accepted.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` - 3 new submitFeedback auth tests pass; no new uncaught exceptions introduced (the 5 pre-existing TS compile failures on unrelated test files are unchanged from `dev`)
- [x] Confirmed via `grep -rn submitFeedback client/` that the only client call site is `client/parts/UserFeedback/FeedbackPanel/useSubmitFeedback.ts`, which lives inside the logged-in shell - no unauthenticated UI path

## Non-goals
- Rate limiting (separate concern, called out in the plan).