### PR TITLE
fix: prevent non-iterable spread in useFabricIcons

### DIFF
--- a/client/hooks/common/useFabricIcons.ts
+++ b/client/hooks/common/useFabricIcons.ts
@@ -14,7 +14,7 @@ import { getFluentIcons } from 'utils/getFluentIcon'
  */
 export function useFabricIcons(includeFluentIcons = false): ISuggestionItem[] {
   return useMemo(() => {
-    return [...icons, ...(includeFluentIcons && getFluentIcons())]
+    return [...icons, ...(includeFluentIcons ? getFluentIcons() : [])]
       .filter(Boolean)
       .filter((icon) => !!icon.name)
       .map(({ name }) => ({


### PR DESCRIPTION
## Summary
- `useFabricIcons` spread the literal `false` when `includeFluentIcons` was disabled, throwing `TypeError: Invalid attempt to spread non-iterable instance` inside `IconPickerControl`.
- This broke the project/customer edit forms in production.
- Replaced the `&&` short-circuit with a ternary that falls back to `[]`.

## Test plan
- [x] Open a project/customer edit form and confirm the icon picker renders without console errors.
- [x] Verify Fluent icons still load when `includeFluentIcons` is true elsewhere.