### PR TITLE
chore: pin node docker base image to its major version 🔧

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,3 +70,10 @@ updates:
     commit-message:
       prefix: 'chore'
       include: scope
+    ignore:
+      # Pin the Node base image to the major version chosen in .nvmrc /
+      # package.json engines. Bumping across majors must be a deliberate
+      # project-wide change (see chore/node-24), not a silent dep PR.
+      - dependency-name: 'node'
+        update-types:
+          - 'version-update:semver-major'


### PR DESCRIPTION
## Summary

Dependabot just opened #1395 bumping `node:24-alpine` to `node:26-alpine` because Node 26 (released April 2026) is the latest upstream tag. We deliberately picked Node 24 LTS in #1389; cross-major bumps should be an explicit project-wide change, not a silent dep PR.

Adds a docker-ecosystem `ignore` rule on `dependency-name: node` for `version-update:semver-major`. Patch and minor bumps still flow through (so we still get `24.7 → 24.8` PRs).

## Follow-up

After this merges, close #1395 manually (or let it stay open; the next dependabot run after this is merged will close it as superseded since the major bump rule will be blocked).