### PR TITLE
chore: narrow dependabot to github-actions only 🔧

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,46 +1,19 @@
 version: 2
-updates:
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
-      day: monday
-      time: '06:00'
-      timezone: Europe/Oslo
-    open-pull-requests-limit: 10
-    target-branch: dev
-    labels:
-      - dependencies
-    commit-message:
-      prefix: 'chore'
-      include: scope
-    groups:
-      fluentui:
-        patterns:
-          - '@fluentui/*'
-          - '@fluentui-contrib/*'
-      apollo:
-        patterns:
-          - '@apollo/*'
-          - 'apollo-*'
-      babel:
-        patterns:
-          - '@babel/*'
-      typescript:
-        patterns:
-          - typescript
-          - 'ts-*'
-          - '@types/*'
-      eslint:
-        patterns:
-          - eslint
-          - 'eslint-*'
-          - '@typescript-eslint/*'
-      test:
-        patterns:
-          - ava
-          - sinon
 
+# Scope: github-actions only.
+#
+# Why not npm or docker?
+#   Weekly auto-bumps for application dependencies generated more triage cost
+#   than security value. Application deps (npm, docker) are now bumped
+#   intentionally on `chore/deps-YYYY-MM` branches by a human, in batches,
+#   with local verification. Security patches still arrive automatically via
+#   GitHub's native "Dependabot security updates" (repo Settings -> Code
+#   security), which is CVE-only and far quieter than version updates.
+#
+# We keep github-actions updates here because action tags rarely break
+# anything, often pin to specific commits/majors, and CVE relevance for CI
+# actions is real.
+updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -55,25 +28,3 @@ updates:
     commit-message:
       prefix: 'chore'
       include: scope
-
-  - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: weekly
-      day: monday
-      time: '06:00'
-      timezone: Europe/Oslo
-    target-branch: dev
-    labels:
-      - dependencies
-      - docker
-    commit-message:
-      prefix: 'chore'
-      include: scope
-    ignore:
-      # Pin the Node base image to the major version chosen in .nvmrc /
-      # package.json engines. Bumping across majors must be a deliberate
-      # project-wide change (see chore/node-24), not a silent dep PR.
-      - dependency-name: 'node'
-        update-types:
-          - 'version-update:semver-major'


### PR DESCRIPTION
## Summary

Replaces the broad npm/docker/github-actions dependabot config (#1388) with a github-actions-only setup.

### Why

The initial broad config produced 12+ PRs in a single sweep, several already failing CI on real incompatibilities (Apollo, FluentUI, ESLint, TypeScript, Babel groups). For a production multi-tenant SaaS, weekly application-dep auto-bumps are net-negative triage cost. The security value comes from CVE patches, not from chasing minor version churn.

### New strategy

| Source | Cadence | Coverage |
|---|---|---|
| This config | weekly | github-actions only (rarely break, often CVE-relevant) |
| GitHub native "Dependabot security updates" (repo Settings -> Code security) | event-driven | npm + docker + everything else, CVE-only |
| `chore/deps-YYYY-MM` branches | manual, periodic | npm + docker version updates, batched, locally verified |

This is also superseding #1407 (which added a `node` major-bump ignore to the docker ecosystem) - the docker ecosystem is gone entirely, so the ignore rule isn't needed.

## ⚠️ Required follow-ups

- [ ] Repo Settings -> Code security -> verify **Dependabot alerts** and **Dependabot security updates** are both enabled (this is the safety net for CVEs after we removed npm/docker from the config)
- [ ] Close #1407 as superseded by this PR
- [ ] Close the in-flight noisy PRs: #1390-1394, #1396-1406 (will do in this PR's merge commit via comment, or by hand)

## Test plan

- [ ] Dependabot's next scheduled run (next Monday 06:00 Europe/Oslo) opens only github-actions PRs, not npm/docker
- [ ] Security alerts still fire for genuine CVEs (test by checking the Security tab)