### PR TITLE
chore: bump GitHub Actions to v5 majors (Node 24 runtime) ⬆️

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -112,7 +112,7 @@ This directory contains all GitHub Actions workflows for the **did** project.
 - Removed lint job from PR workflow (handled by automatic_chores)
 
 ### ✅ Standardization
-- All workflows now use actions@v4 (was mixed v3/v4)
+- All workflows pinned to current major: `actions/*@v5`, `azure/webapps-deploy@v3` (Node 24 compatible)
 - Consistent Node.js setup pattern across all jobs
 - Standardized on `cache: 'npm'` for faster dependency installs
 
@@ -136,9 +136,9 @@ For `dev` branch:
 
 ### Node.js Setup Pattern
 ```yaml
-- uses: actions/checkout@v4
+- uses: actions/checkout@v5
 - name: Use Node.js (${{ vars.NODE_VERSION }})
-  uses: actions/setup-node@v4
+  uses: actions/setup-node@v5
   with:
     node-version: ${{ vars.NODE_VERSION }}
     cache: 'npm'

--- a/.github/workflows/automatic_chores.yml
+++ b/.github/workflows/automatic_chores.yml
@@ -26,13 +26,13 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Use Node.js (${{ vars.NODE_VERSION }})
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ vars.NODE_VERSION }}
           cache: "npm"

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -29,10 +29,10 @@ jobs:
       group: deploy-${{ inputs.environment }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js (${{ vars.NODE_VERSION }})
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ vars.NODE_VERSION }}
           cache: 'npm'
@@ -50,7 +50,7 @@ jobs:
           DISPLAY_VERSION_DETAILS: ${{ inputs.display-version-details }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: did-package-${{ inputs.environment }}
           path: ./did-package.zip
@@ -64,7 +64,7 @@ jobs:
       url: ${{ steps.deploy-to-app-slot.outputs.webapp-url }}
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: did-package-${{ inputs.environment }}
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Gather git metadata
         id: git_meta

--- a/.github/workflows/on_pr_test_build.yml
+++ b/.github/workflows/on_pr_test_build.yml
@@ -17,12 +17,12 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
       
       - name: Use Node.js (${{ vars.NODE_VERSION }})
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ vars.NODE_VERSION }}
           cache: 'npm'
@@ -41,12 +41,12 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
       
       - name: Use Node.js (${{ vars.NODE_VERSION }})
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ vars.NODE_VERSION }}
           cache: 'npm'
@@ -70,12 +70,12 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
       
       - name: Use Node.js (${{ vars.NODE_VERSION }})
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ vars.NODE_VERSION }}
           cache: 'npm'


### PR DESCRIPTION
## Summary

Resolves the GitHub Actions Node 20 deprecation warning seen in recent deploys.

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20: \`actions/checkout@v4\`, \`actions/setup-node@v4\`, \`actions/upload-artifact@v4\`. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

### Bumps

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | v5 |
| `actions/setup-node` | v4 | v5 |
| `actions/upload-artifact` | v4 | v5 |
| `actions/download-artifact` | v4 | v5 |

### Why v5 (not latest)

Dependabot was suggesting `checkout@v6`, `upload@v7`, `download@v8` (the actual latest majors of each). Going to v5 across the board instead because:

1. **Smallest jump that addresses the warning.** v5 of all four runs on Node 24.
2. **Keeps `upload-artifact` and `download-artifact` major-paired.** Mismatched majors between these two are a known footgun — the artifact protocol shifted between v4 and v5.
3. **Less surface area for breaking changes** than walking through 2-3 majors in a single PR.

We can chase v6/v7/v8 later when there's a reason to, on a dedicated branch with a release-notes read.

### Supersedes

- #1391 (checkout v4→v6)
- #1393 (download-artifact v4→v8)

Both will be closed once this lands.

### Also touched

- `.github/workflows/README.md` — example snippets bumped to v5; the "Standardization" section corrected (it previously claimed everything was on v4, which was the truth at write time).

## Test plan

- [ ] PR's own Test build run is green on v5 actions
- [ ] After merge, dev deploy succeeds (the Node 20 deprecation warning should be gone from the run summary)